### PR TITLE
chore: Regenerate all APIs to update copyright year

### DIFF
--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.CreateAdBreakSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.DeleteAdBreakSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.GetAdBreakSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.ListAdBreaksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdBreakServiceClient.UpdateAdBreakSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchAllowAdReviewCenterAdsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.BatchBlockAdReviewCenterAdsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdReviewCenterAdServiceClient.SearchAdReviewCenterAdsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchActivateAdUnitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchArchiveAdUnitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchCreateAdUnitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchDeactivateAdUnitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.BatchUpdateAdUnitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.CreateAdUnitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.GetAdUnitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitSizesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.ListAdUnitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AdUnitServiceClient.UpdateAdUnitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.GetApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ApplicationServiceClient.ListApplicationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.GetAudienceSegmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/AudienceSegmentServiceClient.ListAudienceSegmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.GetBandwidthGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BandwidthGroupServiceClient.ListBandwidthGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.GetBrowserLanguageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserLanguageServiceClient.ListBrowserLanguagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.GetBrowserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/BrowserServiceClient.ListBrowsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.GetCmsMetadataKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataKeyServiceClient.ListCmsMetadataKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.GetCmsMetadataValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CmsMetadataValueServiceClient.ListCmsMetadataValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.GetCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CompanyServiceClient.ListCompaniesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchCreateContactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.BatchUpdateContactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.CreateContactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.GetContactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.ListContactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContactServiceClient.UpdateContactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.GetContentBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentBundleServiceClient.ListContentBundlesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.GetContentLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentLabelServiceClient.ListContentLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.GetContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ContentServiceClient.ListContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.GetCreativeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CreativeTemplateServiceClient.ListCreativeTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchActivateCustomFieldsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchCreateCustomFieldsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchDeactivateCustomFieldsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.BatchUpdateCustomFieldsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.CreateCustomFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.GetCustomFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.ListCustomFieldsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomFieldServiceClient.UpdateCustomFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchActivateCustomTargetingKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchCreateCustomTargetingKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchDeactivateCustomTargetingKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.BatchUpdateCustomTargetingKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.CreateCustomTargetingKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.GetCustomTargetingKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.ListCustomTargetingKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeyAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingKeyServiceClient.UpdateCustomTargetingKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.GetCustomTargetingValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/CustomTargetingValueServiceClient.ListCustomTargetingValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilitySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.GetDeviceCapabilitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCapabilityServiceClient.ListDeviceCapabilitiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategorySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.GetDeviceCategorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceCategoryServiceClient.ListDeviceCategoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.GetDeviceManufacturerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/DeviceManufacturerServiceClient.ListDeviceManufacturersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchCreateEntitySignalsMappingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.BatchUpdateEntitySignalsMappingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.CreateEntitySignalsMappingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.GetEntitySignalsMappingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.ListEntitySignalsMappingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/EntitySignalsMappingServiceClient.UpdateEntitySignalsMappingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.GetGeoTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/GeoTargetServiceClient.ListGeoTargetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.GetLineItemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/LineItemServiceClient.ListLineItemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.GetMobileCarrierSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileCarrierServiceClient.ListMobileCarriersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.GetMobileDeviceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceServiceClient.ListMobileDevicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.GetMobileDeviceSubmodelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/MobileDeviceSubmodelServiceClient.ListMobileDeviceSubmodelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.GetNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.ListNetworksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.ListNetworksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.ListNetworksRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/NetworkServiceClient.ListNetworksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.GetOperatingSystemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemServiceClient.ListOperatingSystemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.GetOperatingSystemVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OperatingSystemVersionServiceClient.ListOperatingSystemVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.GetOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/OrderServiceClient.ListOrdersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchActivatePlacementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchArchivePlacementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchCreatePlacementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchDeactivatePlacementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.BatchUpdatePlacementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.CreatePlacementSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.GetPlacementSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.ListPlacementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PlacementServiceClient.UpdatePlacementSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.CreatePrivateAuctionDealSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.GetPrivateAuctionDealSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.ListPrivateAuctionDealsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionDealServiceClient.UpdatePrivateAuctionDealSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.CreatePrivateAuctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.GetPrivateAuctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.ListPrivateAuctionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/PrivateAuctionServiceClient.UpdatePrivateAuctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.GetProgrammaticBuyerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ProgrammaticBuyerServiceClient.ListProgrammaticBuyersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.CreateReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.FetchReportResultRowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.GetReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.ListReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.RunReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/ReportServiceClient.UpdateReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.GetRoleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/RoleServiceClient.ListRolesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchCreateSitesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchDeactivateSitesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchSubmitSitesForApprovalSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.BatchUpdateSitesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.CreateSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.GetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.ListSitesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/SiteServiceClient.UpdateSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategorySnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.GetTaxonomyCategorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TaxonomyCategoryServiceClient.ListTaxonomyCategoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchActivateTeamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchCreateTeamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchDeactivateTeamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.BatchUpdateTeamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.CreateTeamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.GetTeamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.ListTeamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/TeamServiceClient.UpdateTeamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserSnippet.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.GeneratedSnippets/UserServiceClient.GetUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AdBreakServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AdBreakServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AdReviewCenterAdServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AdReviewCenterAdServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AdUnitServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AdUnitServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ApplicationServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ApplicationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AudienceSegmentServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/AudienceSegmentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/BandwidthGroupServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/BandwidthGroupServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/BrowserLanguageServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/BrowserLanguageServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/BrowserServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/BrowserServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CmsMetadataKeyServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CmsMetadataKeyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CmsMetadataValueServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CmsMetadataValueServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CompanyServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CompanyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContactServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContactServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContentBundleServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContentBundleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContentLabelServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContentLabelServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContentServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ContentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CreativeTemplateServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CreativeTemplateServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CustomFieldServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CustomFieldServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CustomTargetingKeyServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CustomTargetingKeyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CustomTargetingValueServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/CustomTargetingValueServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/DeviceCapabilityServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/DeviceCapabilityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/DeviceCategoryServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/DeviceCategoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/DeviceManufacturerServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/DeviceManufacturerServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/EntitySignalsMappingServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/EntitySignalsMappingServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/GeoTargetServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/GeoTargetServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/LineItemServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/LineItemServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/MobileCarrierServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/MobileCarrierServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/MobileDeviceServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/MobileDeviceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/MobileDeviceSubmodelServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/MobileDeviceSubmodelServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/NetworkServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/NetworkServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/OperatingSystemServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/OperatingSystemServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/OperatingSystemVersionServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/OperatingSystemVersionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/OrderServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/OrderServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/PlacementServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/PlacementServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/PrivateAuctionDealServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/PrivateAuctionDealServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/PrivateAuctionServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/PrivateAuctionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ProgrammaticBuyerServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ProgrammaticBuyerServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ReportServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/ReportServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/RoleServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/RoleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/SiteServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/SiteServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/TaxonomyCategoryServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/TaxonomyCategoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/TeamServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/TeamServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/UserServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.Snippets/UserServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdBreakMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdBreakMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdBreakServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdBreakServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdBreakServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdBreakServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdReviewCenterAdMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdReviewCenterAdMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdReviewCenterAdServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdReviewCenterAdServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdReviewCenterAdServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdReviewCenterAdServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ApplicationMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ApplicationMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ApplicationServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ApplicationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ApplicationServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ApplicationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AppliedLabelResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AppliedLabelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AudienceSegmentMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AudienceSegmentMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AudienceSegmentServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AudienceSegmentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AudienceSegmentServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AudienceSegmentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BandwidthGroupMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BandwidthGroupMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BandwidthGroupServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BandwidthGroupServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BandwidthGroupServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BandwidthGroupServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserLanguageMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserLanguageMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserLanguageServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserLanguageServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserLanguageServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserLanguageServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/BrowserServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataKeyMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataKeyMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataKeyServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataKeyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataKeyServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataKeyServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataValueMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataValueMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataValueServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataValueServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataValueServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CmsMetadataValueServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CompanyMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CompanyMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CompanyServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CompanyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CompanyServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CompanyServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContactMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContactMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContactServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContactServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContactServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContactServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentBundleMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentBundleMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentBundleServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentBundleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentBundleServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentBundleServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentLabelMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentLabelMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentLabelServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentLabelServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentLabelServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentLabelServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ContentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CreativeTemplateMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CreativeTemplateMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CreativeTemplateServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CreativeTemplateServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CreativeTemplateServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CreativeTemplateServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldValueResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomFieldValueResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingKeyMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingKeyMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingKeyServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingKeyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingKeyServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingKeyServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingValueMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingValueMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingValueServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingValueServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingValueServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/CustomTargetingValueServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCapabilityMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCapabilityMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCapabilityServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCapabilityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCapabilityServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCapabilityServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCategoryMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCategoryMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCategoryServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCategoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCategoryServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceCategoryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceManufacturerMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceManufacturerMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceManufacturerServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceManufacturerServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceManufacturerServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/DeviceManufacturerServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/EntitySignalsMappingMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/EntitySignalsMappingMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/EntitySignalsMappingServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/EntitySignalsMappingServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/EntitySignalsMappingServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/EntitySignalsMappingServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/GeoTargetMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/GeoTargetMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/GeoTargetServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/GeoTargetServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/GeoTargetServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/GeoTargetServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LabelMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LabelMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LineItemMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LineItemMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LineItemServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LineItemServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LineItemServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LineItemServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LiveStreamEventMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/LiveStreamEventMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileCarrierMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileCarrierMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileCarrierServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileCarrierServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileCarrierServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileCarrierServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceSubmodelMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceSubmodelMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceSubmodelServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceSubmodelServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceSubmodelServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/MobileDeviceSubmodelServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/NetworkMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/NetworkMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/NetworkServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/NetworkServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/NetworkServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/NetworkServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemVersionMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemVersionMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemVersionServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemVersionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemVersionServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OperatingSystemVersionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OrderMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OrderMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OrderServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OrderServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OrderServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/OrderServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PlacementMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PlacementMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PlacementServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PlacementServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PlacementServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PlacementServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionDealMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionDealMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionDealServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionDealServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionDealServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionDealServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/PrivateAuctionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ProgrammaticBuyerMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ProgrammaticBuyerMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ProgrammaticBuyerServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ProgrammaticBuyerServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ProgrammaticBuyerServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ProgrammaticBuyerServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ReportMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ReportMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ReportServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ReportServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ReportServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ReportServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/RoleMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/RoleMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/RoleServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/RoleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/RoleServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/RoleServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/SiteMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/SiteMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/SiteServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/SiteServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/SiteServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/SiteServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TargetingResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TargetingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TaxonomyCategoryMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TaxonomyCategoryMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TaxonomyCategoryServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TaxonomyCategoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TaxonomyCategoryServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TaxonomyCategoryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TeamMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TeamMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TeamServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TeamServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TeamServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/TeamServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/UserMessagesResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/UserMessagesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/UserServiceClient.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/UserServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/UserServiceResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/UserServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/WebPropertyResourceNames.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/WebPropertyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestAudienceMembersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestAudienceMembersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestAudienceMembersRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestAudienceMembersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.IngestEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RemoveAudienceMembersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RemoveAudienceMembersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RemoveAudienceMembersRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RemoveAudienceMembersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RetrieveRequestStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RetrieveRequestStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RetrieveRequestStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.GeneratedSnippets/IngestionServiceClient.RetrieveRequestStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.Snippets/IngestionServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1.Snippets/IngestionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1/IngestionServiceClient.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1/IngestionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Ads.DataManager.V1/Google.Ads.DataManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.CreateAnalyticsAccountLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.DeleteAnalyticsAccountLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.FindSalesPartnerManagedClientsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.FindSalesPartnerManagedClientsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.FindSalesPartnerManagedClientsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.FindSalesPartnerManagedClientsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.GetOrganizationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListAnalyticsAccountLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListOrganizationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListOrganizationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListOrganizationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ListOrganizationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.ReportPropertyUsageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelRequestObjectSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelSnippet.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.GeneratedSnippets/MarketingplatformAdminServiceClient.SetPropertyServiceLevelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.Snippets/MarketingplatformAdminServiceClientSnippets.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha.Snippets/MarketingplatformAdminServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/MarketingplatformAdminResourceNames.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/MarketingplatformAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/MarketingplatformAdminServiceClient.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/MarketingplatformAdminServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/PackageApiMetadata.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/ResourcesResourceNames.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ApproveDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ApproveDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ApproveDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ApproveDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveAudienceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveAudienceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveAudienceRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveAudienceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchCreateAccessBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchCreateAccessBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchCreateAccessBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchCreateAccessBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchDeleteAccessBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchDeleteAccessBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchDeleteAccessBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchDeleteAccessBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchGetAccessBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchGetAccessBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchGetAccessBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchGetAccessBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchUpdateAccessBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchUpdateAccessBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchUpdateAccessBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.BatchUpdateAccessBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CancelDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CancelDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CancelDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CancelDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames1Snippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames2Snippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAdSenseLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateAudienceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateBigQueryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCalculatedMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateChannelGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkProposalSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDisplayVideo360AdvertiserLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventCreateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateEventEditRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateExpandedDataSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateReportingDataAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateRollupPropertySourceLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSKAdNetworkConversionValueSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSearchAds360LinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.CreateSubpropertyEventFilterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAdSenseLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteBigQueryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteCalculatedMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteChannelGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkProposalSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDisplayVideo360AdvertiserLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventCreateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteEventEditRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteExpandedDataSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteReportingDataAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteRollupPropertySourceLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSKAdNetworkConversionValueSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSearchAds360LinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteSubpropertyEventFilterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAdSenseLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAttributionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetAudienceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetBigQueryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCalculatedMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetChannelGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRedactionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkProposalSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetDisplayVideo360AdvertiserLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEnhancedMeasurementSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventCreateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetEventEditRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetExpandedDataSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGlobalSiteTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetGoogleSignalsSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingDataAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetReportingIdentitySettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetRollupPropertySourceLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSKAdNetworkConversionValueSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSearchAds360LinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertyEventFilterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.GetSubpropertySyncConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames1Snippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames2Snippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccessBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAdSenseLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListAudiencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListBigQueryLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCalculatedMetricsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListChannelGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinkProposalsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListDisplayVideo360AdvertiserLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventCreateRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListEventEditRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListExpandedDataSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListReportingDataAnnotationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListRollupPropertySourceLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSKAdNetworkConversionValueSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSearchAds360LinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertyEventFiltersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ListSubpropertySyncConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionSubpropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionSubpropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionSubpropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionSubpropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ReorderEventEditRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ReorderEventEditRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ReorderEventEditRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.ReorderEventEditRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.SubmitUserDeletionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAttributionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAudienceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateBigQueryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCalculatedMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateChannelGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRedactionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDisplayVideo360AdvertiserLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEnhancedMeasurementSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventCreateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateEventEditRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateExpandedDataSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleSignalsSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateReportingDataAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSKAdNetworkConversionValueSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSearchAds360LinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertyEventFilterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateSubpropertySyncConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.Snippets/AnalyticsAdminServiceClientSnippets.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha.Snippets/AnalyticsAdminServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AnalyticsAdminResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AnalyticsAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AnalyticsAdminServiceClient.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AnalyticsAdminServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AudienceResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/AudienceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ChannelGroupResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ChannelGroupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/EventCreateAndEditResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/EventCreateAndEditResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ExpandedDataSetResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ExpandedDataSetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/PackageApiMetadata.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ResourcesResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/SubpropertyEventFilterResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha/SubpropertyEventFilterResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.AcknowledgeUserDataCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ArchiveCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateFirebaseLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateGoogleAdsLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreateMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.CreatePropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteFirebaseLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteGoogleAdsLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeleteMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.DeletePropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataRetentionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataSharingSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.GetPropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountSummariesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListConversionEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomDimensionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListCustomMetricsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListDataStreamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListFirebaseLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListGoogleAdsLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListKeyEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListMeasurementProtocolSecretsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ListPropertiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.ProvisionAccountTicketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.RunAccessReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.SearchChangeHistoryEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateConversionEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomDimensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateCustomMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataRetentionSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateDataStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateGoogleAdsLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateKeyEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdateMeasurementProtocolSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertySnippet.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.GeneratedSnippets/AnalyticsAdminServiceClient.UpdatePropertySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.Snippets/AnalyticsAdminServiceClientSnippets.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta.Snippets/AnalyticsAdminServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/AnalyticsAdminResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/AnalyticsAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/AnalyticsAdminServiceClient.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/AnalyticsAdminServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/ResourcesResourceNames.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunPivotReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunPivotReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunPivotReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunPivotReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.BatchRunReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CheckCompatibilityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CheckCompatibilityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CheckCompatibilityRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CheckCompatibilityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.CreateAudienceExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetAudienceExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.GetMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.ListAudienceExportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.QueryAudienceExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunPivotReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunPivotReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunPivotReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunPivotReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunRealtimeReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunRealtimeReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunRealtimeReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunRealtimeReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.GeneratedSnippets/BetaAnalyticsDataClient.RunReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.Snippets/BetaAnalyticsDataClientSnippets.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta.Snippets/BetaAnalyticsDataClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/AnalyticsDataApiResourceNames.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/AnalyticsDataApiResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/BetaAnalyticsDataClient.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/BetaAnalyticsDataClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CompleteImportSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CompleteImportSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CompleteImportSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CompleteImportSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateCustomEmojiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateMessageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateReactionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.CreateSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteCustomEmojiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteMessageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteReactionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.DeleteSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.FindDirectMessageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.FindDirectMessageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.FindDirectMessageRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.FindDirectMessageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetCustomEmojiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetMessageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceNotificationSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceReadStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.GetThreadReadStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListCustomEmojisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMembershipsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListMessagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListReactionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpaceEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.ListSpacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SearchSpacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SetUpSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SetUpSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SetUpSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.SetUpSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateMessageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceNotificationSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceReadStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UpdateSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UploadAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UploadAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UploadAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.GeneratedSnippets/ChatServiceClient.UploadAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.Snippets/ChatServiceClientSnippets.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1.Snippets/ChatServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/AnnotationResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/AnnotationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/AttachmentResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/AttachmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ChatServiceClient.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ChatServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/MembershipResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/MembershipResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/MessageResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/MessageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ReactionResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ReactionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceEventResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceEventResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceNotificationSettingResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceNotificationSettingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceReadStateResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceReadStateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/SpaceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ThreadReadStateResourceNames.g.cs
+++ b/apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1/ThreadReadStateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.Snippets/SubscriptionsServiceClientSnippets.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1.Snippets/SubscriptionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/SubscriptionResourceResourceNames.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/SubscriptionResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/SubscriptionsServiceClient.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/SubscriptionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/SubscriptionsServiceResourceNames.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1/SubscriptionsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.CreateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.DeleteSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.GetSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ListSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.ReactivateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionSnippet.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.GeneratedSnippets/SubscriptionsServiceClient.UpdateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.Snippets/SubscriptionsServiceClientSnippets.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta.Snippets/SubscriptionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/SubscriptionResourceResourceNames.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/SubscriptionResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/SubscriptionsServiceClient.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/SubscriptionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/SubscriptionsServiceResourceNames.g.cs
+++ b/apis/Google.Apps.Events.Subscriptions.V1Beta/Google.Apps.Events.Subscriptions.V1Beta/SubscriptionsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntrySnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.CreateSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.GetSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.GeneratedSnippets/SpacesServiceClient.UpdateSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.Snippets/ConferenceRecordsServiceClientSnippets.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.Snippets/ConferenceRecordsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.Snippets/SpacesServiceClientSnippets.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2.Snippets/SpacesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ConferenceRecordsServiceClient.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ConferenceRecordsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ResourceResourceNames.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ServiceResourceNames.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/SpacesServiceClient.g.cs
+++ b/apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2/SpacesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetConferenceRecordSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetRecordingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntrySnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.GetTranscriptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListConferenceRecordsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListParticipantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListRecordingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/ConferenceRecordsServiceClient.ListTranscriptsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ConnectActiveConferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateMemberSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.CreateSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.DeleteMemberSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.EndActiveConferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetMemberSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.GetSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersResourceNamesSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.ListMembersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceSnippet.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.GeneratedSnippets/SpacesServiceClient.UpdateSpaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.Snippets/ConferenceRecordsServiceClientSnippets.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.Snippets/ConferenceRecordsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.Snippets/SpacesServiceClientSnippets.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta.Snippets/SpacesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ConferenceRecordsServiceClient.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ConferenceRecordsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ResourceResourceNames.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ServiceResourceNames.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/SpacesServiceClient.g.cs
+++ b/apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta/SpacesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchCreateRowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchCreateRowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchCreateRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchCreateRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchDeleteRowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchDeleteRowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchDeleteRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchDeleteRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchUpdateRowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchUpdateRowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchUpdateRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.BatchUpdateRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.CreateRowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowResourceNamesSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.DeleteRowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowResourceNamesSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetRowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableResourceNamesSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.GetWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListRowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListTablesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListTablesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListTablesRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListTablesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListWorkspacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListWorkspacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListWorkspacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.ListWorkspacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowSnippet.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.GeneratedSnippets/TablesServiceClient.UpdateRowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.Snippets/TablesServiceClientSnippets.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1.Snippets/TablesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/PackageApiMetadata.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/TablesResourceNames.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/TablesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/TablesServiceClient.g.cs
+++ b/apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1/TablesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DataFoundryServiceClient.GenerateSyntheticDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DataFoundryServiceClient.GenerateSyntheticDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DataFoundryServiceClient.GenerateSyntheticDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DataFoundryServiceClient.GenerateSyntheticDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQuerySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ExportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ImportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDataItemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.DeployModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.GetEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.ListEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UndeployModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FeatureViewDirectWriteSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FeatureViewDirectWriteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.CreateIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.DeleteIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.GetIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.ListIndexesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpdateIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CancelNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.CreateNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.DeleteNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListCustomJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/LlmUtilityServiceClient.CountTokensSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListArtifactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.CopyModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ExportModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.GetModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.ListModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UpdateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ModelServiceClient.UploadModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.EmbedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ExplainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.GenerateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.RawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ServerStreamingPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.ServerStreamingPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamDirectPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamDirectPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamDirectRawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamDirectRawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamingPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamingPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamingRawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/PredictionServiceClient.StreamingRawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.StreamQueryReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.StreamQueryReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.GetScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.CreateTrialSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.DeleteTrialSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.GetTrialSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListStudiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.ListTrialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.LookupStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/DataFoundryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/DataFoundryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/DatasetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/DatasetServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/DeploymentResourcePoolServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/DeploymentResourcePoolServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/EndpointServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/EndpointServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/EvaluationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/EvaluationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeatureOnlineStoreAdminServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeatureOnlineStoreAdminServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeatureOnlineStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeatureOnlineStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeatureRegistryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeatureRegistryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeaturestoreOnlineServingServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeaturestoreOnlineServingServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeaturestoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/FeaturestoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/GenAiCacheServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/GenAiCacheServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/GenAiTuningServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/GenAiTuningServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/IndexEndpointServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/IndexEndpointServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/IndexServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/IndexServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/JobServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/JobServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/LlmUtilityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/LlmUtilityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/MatchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/MatchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/MetadataServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/MetadataServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/MigrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/MigrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ModelGardenServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ModelGardenServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ModelServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ModelServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/NotebookServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/NotebookServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/PersistentResourceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/PersistentResourceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/PipelineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/PipelineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/PredictionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/PredictionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ReasoningEngineExecutionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ReasoningEngineExecutionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ReasoningEngineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ReasoningEngineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ScheduleServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/ScheduleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/SpecialistPoolServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/SpecialistPoolServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/TensorboardServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/TensorboardServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/VertexRagDataServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/VertexRagDataServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/VertexRagServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/VertexRagServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/VizierServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.Snippets/VizierServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/AnnotationResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/AnnotationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/AnnotationSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/AnnotationSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ApiAuthResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ApiAuthResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/BatchPredictionJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/BatchPredictionJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/CachedContentResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/CachedContentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ContentResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ContentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ContextResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ContextResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/CustomJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/CustomJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataFoundryServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataFoundryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataFoundryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataFoundryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataItemResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataItemResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataLabelingJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DataLabelingJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DatasetVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeployedIndexRefResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeployedIndexRefResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeployedModelRefResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeployedModelRefResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeploymentResourcePoolResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeploymentResourcePoolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeploymentResourcePoolServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeploymentResourcePoolServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeploymentResourcePoolServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/DeploymentResourcePoolServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EndpointServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EvaluationServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EvaluationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EvaluationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EvaluationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EventResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/EventResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ExecutionResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ExecutionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureGroupResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureGroupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreAdminServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreAdminServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreAdminServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreAdminServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureOnlineStoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureRegistryServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureRegistryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureRegistryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureRegistryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureViewResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureViewResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureViewSyncResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeatureViewSyncResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreOnlineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreOnlineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreOnlineServingServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreOnlineServingServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/FeaturestoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenAiCacheServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenAiCacheServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenAiCacheServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenAiCacheServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenAiTuningServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenAiTuningServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenaiTuningServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/GenaiTuningServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/HyperparameterTuningJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/HyperparameterTuningJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexEndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexEndpointResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexEndpointServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexEndpointServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexEndpointServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexEndpointServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/IndexServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/JobServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/JobServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/JobServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/LlmUtilityServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/LlmUtilityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/LlmUtilityServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/LlmUtilityServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MatchServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MatchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MatchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MatchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataSchemaResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataSchemaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MetadataStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigratableResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigratableResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigrationServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigrationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/MigrationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelDeploymentMonitoringJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelDeploymentMonitoringJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelEvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelEvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelEvaluationSliceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelEvaluationSliceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelGardenServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelGardenServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelGardenServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelGardenServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelMonitoringResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelMonitoringResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ModelServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NasJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NasJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NetworkSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NetworkSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookExecutionJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookExecutionJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookRuntimeResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookRuntimeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookRuntimeTemplateRefResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookRuntimeTemplateRefResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/NotebookServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PersistentResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PersistentResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PersistentResourceServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PersistentResourceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PersistentResourceServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PersistentResourceServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PipelineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PredictionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PredictionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PredictionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PublisherModelResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/PublisherModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineExecutionServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineExecutionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineExecutionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineExecutionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReasoningEngineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReservationAffinityResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ReservationAffinityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SavedQueryResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SavedQueryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ScheduleResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ScheduleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ScheduleServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ScheduleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ScheduleServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ScheduleServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ServiceNetworkingResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ServiceNetworkingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/SpecialistPoolServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/StudyResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/StudyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardExperimentResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardExperimentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardRunResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardRunResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardTimeSeriesResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TensorboardTimeSeriesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ToolResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/ToolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TrainingPipelineResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TrainingPipelineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TuningJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/TuningJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagDataResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagDataResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagDataServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagDataServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagDataServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagDataServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VertexRagServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VizierServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VizierServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VizierServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/VizierServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssembleDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssembleDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssembleDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssembleDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssessDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssessDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssessDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.AssessDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.CreateDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQueryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQuerySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.DeleteSavedQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ExportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetAnnotationSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.GetDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ImportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListAnnotationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDataItemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.ListSavedQueriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.RestoreDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.SearchDataItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DatasetServiceClient.UpdateDatasetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.CreateDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.DeleteDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.GetDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.ListDeploymentResourcePoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.QueryDeployedModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/DeploymentResourcePoolServiceClient.UpdateDeploymentResourcePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpoint2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.CreateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeleteEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.DeployModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.FetchPublisherModelConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.GetEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.ListEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.MutateDeployedModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.SetPublisherModelConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UndeployModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointLongRunningSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EndpointServiceClient.UpdateEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/EvaluationServiceClient.EvaluateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.CreateExampleStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.DeleteExampleStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.FetchExamplesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.FetchExamplesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.FetchExamplesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.FetchExamplesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.GetExampleStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.ListExampleStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.RemoveExamplesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.RemoveExamplesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.RemoveExamplesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.RemoveExamplesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.SearchExamplesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.SearchExamplesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.SearchExamplesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.SearchExamplesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpdateExampleStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpsertExamplesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpsertExamplesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpsertExamplesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExampleStoreServiceClient.UpsertExamplesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.ExecuteExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionExecutionServiceClient.QueryExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.DeleteExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.GetExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ImportExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.ListExtensionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ExtensionRegistryServiceClient.UpdateExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.CreateFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.DeleteFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.GetFeatureViewSyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureOnlineStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewSyncsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.ListFeatureViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.SyncFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureOnlineStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreAdminServiceClient.UpdateFeatureViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FeatureViewDirectWriteSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FeatureViewDirectWriteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.FetchFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.GenerateFetchAccessTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.SearchNearestEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.StreamingFetchFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureOnlineStoreServiceClient.StreamingFetchFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.BatchCreateFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.CreateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.DeleteFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.GetFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeatureMonitorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.ListFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeatureRegistryServiceClient.UpdateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.ReadFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.StreamingReadFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreOnlineServingServiceClient.WriteFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchCreateFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.BatchReadFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeature2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestore2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.CreateFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestore2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.DeleteFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ExportFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.GetFeaturestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ImportFeatureValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.ListFeaturestoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeatures2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.SearchFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/FeaturestoreServiceClient.UpdateFeaturestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.CreateCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.DeleteCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.GetCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.ListCachedContentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiCacheServiceClient.UpdateCachedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CancelTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.CreateTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.GetTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.ListTuningJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/GenAiTuningServiceClient.RebaseTunedModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.CreateIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeleteIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.DeployIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.GetIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.ListIndexEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.MutateDeployedIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UndeployIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexEndpointServiceClient.UpdateIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.CreateIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.DeleteIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.GetIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ImportIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ImportIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ImportIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ImportIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.ListIndexesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.RemoveDatapointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpdateIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/IndexServiceClient.UpsertDatapointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CancelNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.CreateNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.DeleteNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetBatchPredictionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetCustomJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetDataLabelingJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetHyperparameterTuningJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.GetNasTrialDetailSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListBatchPredictionJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListCustomJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListDataLabelingJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListHyperparameterTuningJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListModelDeploymentMonitoringJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ListNasTrialDetailsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.PauseModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.ResumeModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.SearchModelDeploymentMonitoringStatsAnomaliesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/JobServiceClient.UpdateModelDeploymentMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/LlmUtilityServiceClient.ComputeTokensSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.FindNeighborsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MatchServiceClient.ReadIndexDatapointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.CreateMemoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.CreateMemoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.CreateMemoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.CreateMemoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemorySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.DeleteMemorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GenerateMemoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemorySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.GetMemorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.ListMemoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.RetrieveMemoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemorySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MemoryBankServiceClient.UpdateMemorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextArtifactsAndExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddContextChildrenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.AddExecutionEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.CreateMetadataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.DeleteMetadataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.GetMetadataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListArtifactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.ListMetadataStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeArtifactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.PurgeExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryArtifactLineageSubgraphSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryContextLineageSubgraphSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.QueryExecutionInputsAndOutputsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.RemoveContextChildrenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MetadataServiceClient.UpdateExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.BatchMigrateResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/MigrationServiceClient.SearchMigratableResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.AcceptPublisherModelEulaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.CheckPublisherModelEulaAcceptanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployPublisherModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployPublisherModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployPublisherModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployPublisherModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.DeployRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ExportPublisherModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ExportPublisherModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ExportPublisherModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ExportPublisherModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.GetPublisherModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelGardenServiceClient.ListPublisherModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.CreateModelMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.DeleteModelMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.GetModelMonitoringJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitoringJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.ListModelMonitorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringAlertsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.SearchModelMonitoringStatsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelMonitoringServiceClient.UpdateModelMonitorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportEvaluatedAnnotationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.BatchImportModelEvaluationSlicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.CopyModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.DeleteModelVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ExportModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSliceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.GetModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ImportModelEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationSlicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionCheckpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.ListModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.MergeVersionAliasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.RecommendSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.RecommendSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.RecommendSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.RecommendSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateExplanationDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UpdateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ModelServiceClient.UploadModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.AssignNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookExecutionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookExecutionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookExecutionJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookExecutionJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimeTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListNotebookRuntimesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpdateNotebookRuntimeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeNotebookRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.CreatePersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.DeletePersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.GetPersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.ListPersistentResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.RebootPersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PersistentResourceServiceClient.UpdatePersistentResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchCancelPipelineJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.BatchDeletePipelineJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelPipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CancelTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreatePipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.CreateTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeletePipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.DeleteTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetPipelineJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.GetTrainingPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListPipelineJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PipelineServiceClient.ListTrainingPipelinesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ChatCompletionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ChatCompletionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ChatCompletionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ChatCompletionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ChatCompletionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ChatCompletionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.CountTokensSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.DirectRawPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.EmbedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ExplainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.GenerateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.RawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ServerStreamingPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.ServerStreamingPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamDirectPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamDirectPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamDirectRawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamDirectRawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamGenerateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamRawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamingPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamingPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamingRawPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/PredictionServiceClient.StreamingRawPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.QueryReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.StreamQueryReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineExecutionServiceClient.StreamQueryReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.CreateReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.DeleteReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.GetReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.ListReasoningEnginesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ReasoningEngineServiceClient.UpdateReasoningEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.CreateScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.DeleteScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.GetScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ListSchedulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.PauseScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2Snippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeSchedule2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.ResumeScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/ScheduleServiceClient.UpdateScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.AppendEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.CreateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.DeleteSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.GetSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SessionServiceClient.UpdateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.CreateSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.DeleteSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.GetSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.ListSpecialistPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/SpecialistPoolServiceClient.UpdateSpecialistPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchCreateTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.BatchReadTensorboardTimeSeriesDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.CreateTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.DeleteTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ExportTensorboardTimeSeriesDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.GetTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardExperimentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ListTensorboardsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardBlobDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardSizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardTimeSeriesDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.ReadTensorboardUsageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.UpdateTensorboardTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardExperimentDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/TensorboardServiceClient.WriteTensorboardRunDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.CreateRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.DeleteRagFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.GetRagFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ImportRagFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagCorporaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.ListRagFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UpdateRagEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagDataServiceClient.UploadRagFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.AugmentPromptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.CorroborateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VertexRagServiceClient.RetrieveContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.AddTrialMeasurementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CheckTrialEarlyStoppingStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CompleteTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.CreateTrialSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.DeleteTrialSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.GetTrialSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListOptimalTrialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListStudiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.ListTrialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudySnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.LookupStudySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.StopTrialRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.GeneratedSnippets/VizierServiceClient.SuggestTrialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/DatasetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/DatasetServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/DeploymentResourcePoolServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/DeploymentResourcePoolServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/EndpointServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/EndpointServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/EvaluationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/EvaluationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ExampleStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ExampleStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ExtensionExecutionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ExtensionExecutionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ExtensionRegistryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ExtensionRegistryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeatureOnlineStoreAdminServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeatureOnlineStoreAdminServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeatureOnlineStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeatureOnlineStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeatureRegistryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeatureRegistryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeaturestoreOnlineServingServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeaturestoreOnlineServingServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeaturestoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/FeaturestoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/GenAiCacheServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/GenAiCacheServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/GenAiTuningServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/GenAiTuningServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/IndexEndpointServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/IndexEndpointServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/IndexServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/IndexServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/JobServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/JobServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/LlmUtilityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/LlmUtilityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MatchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MatchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MemoryBankServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MemoryBankServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MetadataServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MetadataServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MigrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/MigrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ModelGardenServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ModelGardenServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ModelMonitoringServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ModelMonitoringServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ModelServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ModelServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/NotebookServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/NotebookServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/PersistentResourceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/PersistentResourceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/PipelineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/PipelineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/PredictionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/PredictionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ReasoningEngineExecutionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ReasoningEngineExecutionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ReasoningEngineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ReasoningEngineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ScheduleServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/ScheduleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/SessionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/SessionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/SpecialistPoolServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/SpecialistPoolServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/TensorboardServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/TensorboardServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/VertexRagDataServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/VertexRagDataServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/VertexRagServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/VertexRagServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/VizierServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1.Snippets/VizierServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/AnnotationResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/AnnotationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/AnnotationSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/AnnotationSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ApiAuthResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ApiAuthResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/BatchPredictionJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/BatchPredictionJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/CachedContentResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/CachedContentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ContentResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ContentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ContextResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ContextResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/CustomJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/CustomJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DataItemResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DataItemResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DataLabelingJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DataLabelingJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DatasetVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeployedIndexRefResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeployedIndexRefResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeployedModelRefResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeployedModelRefResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeploymentResourcePoolResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeploymentResourcePoolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeploymentResourcePoolServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeploymentResourcePoolServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeploymentResourcePoolServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/DeploymentResourcePoolServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EndpointResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EndpointServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EndpointServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EndpointServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EndpointServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EvaluationServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EvaluationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EvaluationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EvaluationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EventResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/EventResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExampleStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExampleStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExampleStoreServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExampleStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExampleStoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExampleStoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExecutionResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExecutionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionExecutionServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionExecutionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionExecutionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionExecutionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionRegistryServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionRegistryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionRegistryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionRegistryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ExtensionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureGroupResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureGroupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureMonitorJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureMonitorJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureMonitorResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureMonitorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreAdminServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreAdminServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreAdminServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreAdminServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureOnlineStoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureRegistryServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureRegistryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureRegistryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureRegistryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureViewResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureViewResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureViewSyncResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeatureViewSyncResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreOnlineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreOnlineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreOnlineServingServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreOnlineServingServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/FeaturestoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenAiCacheServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenAiCacheServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenAiCacheServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenAiCacheServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenAiTuningServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenAiTuningServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenaiTuningServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/GenaiTuningServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/HyperparameterTuningJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/HyperparameterTuningJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexEndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexEndpointResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexEndpointServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexEndpointServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexEndpointServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexEndpointServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/IndexServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/JobServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/JobServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/JobServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/LlmUtilityServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/LlmUtilityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/LlmUtilityServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/LlmUtilityServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MatchServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MatchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MatchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MatchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MemoryBankResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MemoryBankResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MemoryBankServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MemoryBankServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MemoryBankServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MemoryBankServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataSchemaResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataSchemaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MetadataStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MigratableResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MigratableResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MigrationServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MigrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MigrationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/MigrationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelDeploymentMonitoringJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelDeploymentMonitoringJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelEvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelEvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelEvaluationSliceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelEvaluationSliceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelGardenServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelGardenServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelGardenServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelGardenServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitorResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelMonitoringSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ModelServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NasJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NasJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NetworkSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NetworkSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookExecutionJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookExecutionJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookRuntimeResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookRuntimeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookRuntimeTemplateRefResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookRuntimeTemplateRefResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/NotebookServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PersistentResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PersistentResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PersistentResourceServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PersistentResourceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PersistentResourceServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PersistentResourceServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PipelineJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PipelineJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PipelineServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PipelineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PipelineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PipelineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PredictionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PredictionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PredictionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PublisherModelResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/PublisherModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineExecutionServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineExecutionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineExecutionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineExecutionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReasoningEngineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReservationAffinityResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ReservationAffinityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SavedQueryResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SavedQueryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ScheduleResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ScheduleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ScheduleServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ScheduleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ScheduleServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ScheduleServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ServiceNetworkingResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ServiceNetworkingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SessionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SessionServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SessionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SessionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SessionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SpecialistPoolResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SpecialistPoolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SpecialistPoolServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SpecialistPoolServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SpecialistPoolServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/SpecialistPoolServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/StudyResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/StudyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardExperimentResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardExperimentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardRunResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardRunResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardTimeSeriesResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TensorboardTimeSeriesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ToolResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/ToolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TrainingPipelineResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TrainingPipelineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TuningJobResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/TuningJobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagDataResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagDataResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagDataServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagDataServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagDataServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagDataServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VertexRagServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VizierServiceClient.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VizierServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VizierServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1/VizierServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ApproveApprovalRequestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ApproveApprovalRequestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ApproveApprovalRequestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ApproveApprovalRequestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DeleteAccessApprovalSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DismissApprovalRequestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DismissApprovalRequestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DismissApprovalRequestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.DismissApprovalRequestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalServiceAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetAccessApprovalSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.GetApprovalRequestSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.InvalidateApprovalRequestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.InvalidateApprovalRequestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.InvalidateApprovalRequestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.InvalidateApprovalRequestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.ListApprovalRequestsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.GeneratedSnippets/AccessApprovalServiceClient.UpdateAccessApprovalSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.Snippets/AccessApprovalServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1.Snippets/AccessApprovalServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/AccessApprovalServiceClient.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/AccessApprovalServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/AccessapprovalResourceNames.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/AccessapprovalResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetNotificationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.GetSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.ListNotificationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.GeneratedSnippets/AdvisoryNotificationsServiceClient.UpdateSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.Snippets/AdvisoryNotificationsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1.Snippets/AdvisoryNotificationsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/AdvisoryNotificationsServiceClient.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/AdvisoryNotificationsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.CreateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.DeleteUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ExportClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.GetUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ImportClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.InjectFaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.ListUsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpdateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.Snippets/AlloyDBAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.Snippets/AlloyDBAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.Snippets/AlloyDBCSQLAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1.Snippets/AlloyDBCSQLAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/AlloyDBAdminClient.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/AlloyDBAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/AlloyDBCSQLAdminClient.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/AlloyDBCSQLAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/CsqlServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/CsqlServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.CreateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.DeleteUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ExportClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.GetUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ImportClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.InjectFaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.ListUsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpdateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.Snippets/AlloyDBAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.Snippets/AlloyDBAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.Snippets/AlloyDBCSQLAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha.Snippets/AlloyDBCSQLAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/AlloyDBAdminClient.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/AlloyDBAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/AlloyDBCSQLAdminClient.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/AlloyDBCSQLAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/CsqlServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/CsqlServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.BatchCreateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateSecondaryInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.CreateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.DeleteUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExecuteSqlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ExportClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.FailoverInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GenerateClientCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetConnectionInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.GetUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ImportClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.InjectFaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListSupportedDatabaseFlagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.ListUsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.PromoteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestartInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.RestoreClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.SwitchoverClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpdateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBAdminClient.UpgradeClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLSnippet.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.GeneratedSnippets/AlloyDBCSQLAdminClient.RestoreFromCloudSQLSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.Snippets/AlloyDBAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.Snippets/AlloyDBAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.Snippets/AlloyDBCSQLAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.Snippets/AlloyDBCSQLAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/AlloyDBAdminClient.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/AlloyDBAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/AlloyDBCSQLAdminClient.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/AlloyDBCSQLAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/CsqlServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/CsqlServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.CreateGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.DeleteGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.GetGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApiConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListApisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.ListGatewaysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.GeneratedSnippets/ApiGatewayServiceClient.UpdateGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.Snippets/ApiGatewayServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1.Snippets/ApiGatewayServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ApiGatewayServiceClient.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ApiGatewayServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ApigatewayResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ApigatewayResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateExternalApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.CreateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteExternalApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.DeleteVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDefinitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetExternalApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecContentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.GetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApiOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListApisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListAttributesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListExternalApisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListSpecsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.ListVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.SearchResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateExternalApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubClient.UpdateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCollectClient.CollectApiDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.CreateCurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.DeleteCurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.GetCurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.ListCurationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubCurateClient.UpdateCurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencySnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.CreateDependencySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencySnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.DeleteDependencySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencySnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.GetDependencySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.ListDependenciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencySnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDependenciesClient.UpdateDependencySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiObservationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.GetDiscoveredApiOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiObservationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubDiscoveryClient.ListDiscoveredApiOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.CreatePluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DeletePluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginInstanceActionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.DisablePluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginInstanceActionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.EnablePluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ExecutePluginInstanceActionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.GetPluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.ListPluginsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ApiHubPluginClient.UpdatePluginInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.CreateHostProjectRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.GetHostProjectRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/HostProjectRegistrationServiceClient.ListHostProjectRegistrationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideContentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.GetStyleGuideSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.LintSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.LintSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.LintSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.LintSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/LintingServiceClient.UpdateStyleGuideSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.CreateApiHubInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.DeleteApiHubInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.GetApiHubInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/ProvisioningClient.LookupApiHubInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.CreateRuntimeProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.DeleteRuntimeProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.GetRuntimeProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.ListRuntimeProjectAttachmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.GeneratedSnippets/RuntimeProjectAttachmentServiceClient.LookupRuntimeProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubCollectClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubCollectClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubCurateClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubCurateClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubDependenciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubDependenciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubDiscoveryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubDiscoveryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubPluginClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ApiHubPluginClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/HostProjectRegistrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/HostProjectRegistrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/LintingServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/LintingServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ProvisioningClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/ProvisioningClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/RuntimeProjectAttachmentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1.Snippets/RuntimeProjectAttachmentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubCollectClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubCollectClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubCurateClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubCurateClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubDependenciesClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubDependenciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubDiscoveryClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubDiscoveryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubPluginClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApiHubPluginClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApihubServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ApihubServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/CollectServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/CollectServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/CommonFieldsResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/CommonFieldsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/CurateServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/CurateServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/DiscoveryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/DiscoveryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/HostProjectRegistrationServiceClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/HostProjectRegistrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/HostProjectRegistrationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/HostProjectRegistrationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/LintingServiceClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/LintingServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/LintingServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/LintingServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/PluginServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/PluginServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ProvisioningClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ProvisioningClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ProvisioningServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ProvisioningServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/RuntimeProjectAttachmentServiceClient.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/RuntimeProjectAttachmentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/RuntimeProjectAttachmentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/RuntimeProjectAttachmentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeySnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.CreateKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeySnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.DeleteKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeySnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.GetKeyStringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.ListKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.LookupKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.LookupKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.LookupKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.LookupKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UndeleteKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UndeleteKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UndeleteKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UndeleteKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeySnippet.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.GeneratedSnippets/ApiKeysClient.UpdateKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.Snippets/ApiKeysClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2.Snippets/ApiKeysClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ApiKeysClient.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ApiKeysClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ApikeysResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ApikeysResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.GetMcpToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpServersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsSnippet.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.GeneratedSnippets/CloudApiRegistryClient.ListMcpToolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.Snippets/CloudApiRegistryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta.Snippets/CloudApiRegistryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/CloudApiRegistryClient.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/CloudApiRegistryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApiRegistry.V1Beta/Google.Cloud.ApiRegistry.V1Beta/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/TetherClient.EgressSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.GeneratedSnippets/TetherClient.EgressSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.Snippets/ConnectionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.Snippets/ConnectionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.Snippets/TetherClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1.Snippets/TetherClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ConnectionResourceNames.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ConnectionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ConnectionServiceClient.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ConnectionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/TetherClient.g.cs
+++ b/apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1/TetherClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/ProvisioningClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateApiVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames5AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames5AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames5Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactResourceNames5Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.CreateArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteApiVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.DeleteArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecContentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetApiVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactContentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.GetArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiSpecsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApiVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListApisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames5AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames5AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames5Snippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsResourceNames5Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ListArtifactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.ReplaceArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.RollbackApiSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiDeploymentRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiDeploymentRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiDeploymentRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiDeploymentRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiSpecRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiSpecRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiSpecRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.TagApiSpecRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.GeneratedSnippets/RegistryClient.UpdateApiVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.Snippets/ProvisioningClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.Snippets/ProvisioningClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.Snippets/RegistryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1.Snippets/RegistryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ProvisioningClient.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ProvisioningClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ProvisioningServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ProvisioningServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/RegistryClient.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/RegistryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/RegistryModelsResourceNames.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/RegistryModelsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/RegistryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/RegistryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.CreateApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.CreateApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.CreateApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.CreateApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.GetApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.RepairApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.RepairApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.RepairApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.RepairApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.UpdateApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.UpdateApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.UpdateApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ApplicationsClient.UpdateApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.CreateAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.CreateAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.CreateAuthorizedCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.CreateAuthorizedCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.DeleteAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.DeleteAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.DeleteAuthorizedCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.DeleteAuthorizedCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.GetAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.GetAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.GetAuthorizedCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.GetAuthorizedCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.ListAuthorizedCertificatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.ListAuthorizedCertificatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.ListAuthorizedCertificatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.ListAuthorizedCertificatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.UpdateAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.UpdateAuthorizedCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.UpdateAuthorizedCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedCertificatesClient.UpdateAuthorizedCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedDomainsClient.ListAuthorizedDomainsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedDomainsClient.ListAuthorizedDomainsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedDomainsClient.ListAuthorizedDomainsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/AuthorizedDomainsClient.ListAuthorizedDomainsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.CreateDomainMappingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.CreateDomainMappingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.CreateDomainMappingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.CreateDomainMappingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.DeleteDomainMappingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.DeleteDomainMappingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.DeleteDomainMappingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.DeleteDomainMappingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.GetDomainMappingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.GetDomainMappingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.GetDomainMappingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.GetDomainMappingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.ListDomainMappingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.ListDomainMappingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.ListDomainMappingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.ListDomainMappingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.UpdateDomainMappingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.UpdateDomainMappingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.UpdateDomainMappingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/DomainMappingsClient.UpdateDomainMappingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.BatchUpdateIngressRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.BatchUpdateIngressRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.BatchUpdateIngressRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.BatchUpdateIngressRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.CreateIngressRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.CreateIngressRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.CreateIngressRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.CreateIngressRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.DeleteIngressRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.DeleteIngressRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.DeleteIngressRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.DeleteIngressRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.GetIngressRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.GetIngressRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.GetIngressRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.GetIngressRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.ListIngressRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.ListIngressRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.ListIngressRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.ListIngressRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.UpdateIngressRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.UpdateIngressRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.UpdateIngressRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/FirewallClient.UpdateIngressRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DebugInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DebugInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DebugInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DebugInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/InstancesClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/ApplicationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/ApplicationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedCertificatesClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedCertificatesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedDomainsClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/AuthorizedDomainsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/DomainMappingsClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/DomainMappingsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/FirewallClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/FirewallClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/InstancesClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/InstancesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/ServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/ServicesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/VersionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1.Snippets/VersionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ApplicationsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ApplicationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedCertificatesClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedCertificatesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedDomainsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/AuthorizedDomainsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/DomainMappingsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/DomainMappingsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/FirewallClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/FirewallClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/InstancesClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/InstancesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServicesClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/ServicesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/VersionsClient.g.cs
+++ b/apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1/VersionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.CreateWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DeleteWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.DetachServiceProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetDiscoveredWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.GetWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListApplicationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListDiscoveredWorkloadsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServiceProjectAttachmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.ListWorkloadsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupDiscoveredWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.LookupServiceProjectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.GeneratedSnippets/AppHubClient.UpdateWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.Snippets/AppHubClientSnippets.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.Snippets/AppHubClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/AppHubClient.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/AppHubClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ApphubServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ApphubServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ApplicationResourceNames.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ApplicationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceProjectAttachmentResourceNames.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceProjectAttachmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/WorkloadResourceNames.g.cs
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/WorkloadResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.BatchDeleteVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.CreateTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeletePackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ExportArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ExportArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ExportArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ExportArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetDockerImageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetMavenArtifactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetNpmPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetPythonPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVPCSCConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.GetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListAttachmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListDockerImagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListMavenArtifactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListNpmPackagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPackagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListPythonPackagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListTagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.ListVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdatePackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVPCSCConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.GeneratedSnippets/ArtifactRegistryClient.UpdateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.Snippets/ArtifactRegistryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1.Snippets/ArtifactRegistryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/AptArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/AptArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ArtifactRegistryClient.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ArtifactRegistryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/AttachmentResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/AttachmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ExportResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ExportResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/FileResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/FileResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/GenericResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/GenericResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/GoResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/GoResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/KfpArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/KfpArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/PackageResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/PackageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/RepositoryResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/RepositoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/RuleResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/RuleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/SettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/SettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/TagResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/TagResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/VersionResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/VersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/VpcscConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/VpcscConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/YumArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1/YumArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.CreateTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeletePackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.DeleteVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetProjectSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.GetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportAptArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ImportYumArtifactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListPackagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListRepositoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListTagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.ListVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateProjectSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagSnippet.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.GeneratedSnippets/ArtifactRegistryClient.UpdateTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets/ArtifactRegistryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2.Snippets/ArtifactRegistryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/AptArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/AptArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ArtifactRegistryClient.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ArtifactRegistryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/FileResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/FileResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/RepositoryResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/RepositoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/SettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/SettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/TagResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/TagResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/VersionResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/VersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/YumArtifactResourceNames.g.cs
+++ b/apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2/YumArtifactResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyLongrunningRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyLongrunningRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyLongrunningRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyLongrunningRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeMoveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeMoveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeMoveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeMoveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.AnalyzeOrgPolicyGovernedContainersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetAssetsHistoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetAssetsHistoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetAssetsHistoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetAssetsHistoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetEffectiveIamPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetEffectiveIamPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetEffectiveIamPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.BatchGetEffectiveIamPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateFeedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQueryResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQuerySnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.CreateSavedQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteFeedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQueryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQuerySnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.DeleteSavedQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ExportAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ExportAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ExportAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ExportAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetFeedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQueryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQuerySnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.GetSavedQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListFeedsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.ListSavedQueriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.QueryAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.QueryAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.QueryAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.QueryAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllIamPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.SearchAllResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateFeedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQuerySnippet.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.GeneratedSnippets/AssetServiceClient.UpdateSavedQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.Snippets/AssetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1.Snippets/AssetServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetsResourceNames.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/AssetsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.AcknowledgeViolationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.AcknowledgeViolationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.AcknowledgeViolationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.AcknowledgeViolationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetViolationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListViolationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.Snippets/AssuredWorkloadsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1.Snippets/AssuredWorkloadsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/AssuredWorkloadsServiceClient.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/AssuredWorkloadsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/AssuredworkloadsResourceNames.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/AssuredworkloadsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.AnalyzeWorkloadMoveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.CreateWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.DeleteWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.GetWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.ListWorkloadsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.RestrictAllowedResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.GeneratedSnippets/AssuredWorkloadsServiceClient.UpdateWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets/AssuredWorkloadsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1.Snippets/AssuredWorkloadsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredWorkloadsServiceClient.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredWorkloadsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredworkloadsResourceNames.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/AssuredworkloadsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.CreateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeleteModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.DeployModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ExportModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetAnnotationSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.GetModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ImportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.ListModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UndeployModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/AutoMlClient.UpdateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.BatchPredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/AutoMlClientSnippets.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/AutoMlClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/PredictionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1.Snippets/PredictionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AnnotationSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AnnotationSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/AutoMlClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/DatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/DatasetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelEvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelEvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/PredictionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.CreateManagementServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.DeleteManagementServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupPlanAssociationsForResourceTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchBackupsForResourceTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchDataSourceReferencesForResourceTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.FetchUsableBackupVaultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceReferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.GetManagementServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.InitializeServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.InitializeServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.InitializeServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.InitializeServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanAssociationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlanRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupPlansSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupVaultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourceReferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListDataSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.ListManagementServersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.RestoreBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.TriggerBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceSnippet.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.GeneratedSnippets/BackupDRClient.UpdateDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.Snippets/BackupDRClientSnippets.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1.Snippets/BackupDRClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupDRClient.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupDRClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupdrResourceNames.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupdrResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupplanResourceNames.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupplanResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupplanassociationResourceNames.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupplanassociationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupvaultCloudsqlResourceNames.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupvaultCloudsqlResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupvaultDiskResourceNames.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupvaultDiskResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupvaultResourceNames.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/BackupvaultResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/DatasourcereferenceResourceNames.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/DatasourcereferenceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateNfsShareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateProvisioningConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeySnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateSSHKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.CreateVolumeSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteNfsShareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeySnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteSSHKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DeleteVolumeSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DetachLunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.DisableInteractiveSerialConsoleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EnableInteractiveSerialConsoleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictLunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.EvictVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetLunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetNfsShareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetProvisioningConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.GetVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListLunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworkUsageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNetworksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListNfsSharesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListOSImagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListProvisioningQuotasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListSSHKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumeSnapshotsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ListVolumesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameNfsShareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RenameVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.ResizeVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.RestoreVolumeSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StartInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.StopInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.SubmitProvisioningConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateNfsShareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateProvisioningConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.GeneratedSnippets/BareMetalSolutionClient.UpdateVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.Snippets/BareMetalSolutionClientSnippets.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2.Snippets/BareMetalSolutionClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/BareMetalSolutionClient.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/BareMetalSolutionClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/LunResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/LunResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/NetworkResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/NetworkResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/NfsShareResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/NfsShareResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/OsimageResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/OsimageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/ProvisioningResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/ProvisioningResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/SshKeyResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/SshKeyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/VolumeResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/VolumeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/VolumeSnapshotResourceNames.g.cs
+++ b/apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2/VolumeSnapshotResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CancelJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.GetTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.GeneratedSnippets/BatchServiceClient.ListTasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.Snippets/BatchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1.Snippets/BatchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/BatchResourceNames.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/BatchResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/BatchServiceClient.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/BatchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/JobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1/TaskResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CancelJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.CreateResourceAllowanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.DeleteResourceAllowanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetResourceAllowanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.GetTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListResourceAllowancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.ListTasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceSnippet.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.GeneratedSnippets/BatchServiceClient.UpdateResourceAllowanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.Snippets/BatchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha.Snippets/BatchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/BatchResourceNames.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/BatchResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/BatchServiceClient.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/BatchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/JobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/ResourceAllowanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/ResourceAllowanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha/TaskResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.CreateAppConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.DeleteAppConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.GetAppConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ListAppConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.ResolveAppConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.GeneratedSnippets/AppConnectionsServiceClient.UpdateAppConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.Snippets/AppConnectionsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1.Snippets/AppConnectionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/AppConnectionsServiceClient.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/AppConnectionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/AppConnectionsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/AppConnectionsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.CreateAppConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.DeleteAppConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.GetAppConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ListAppConnectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.ReportStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.GeneratedSnippets/AppConnectorsServiceClient.UpdateAppConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.Snippets/AppConnectorsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1.Snippets/AppConnectorsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/AppConnectorsServiceClient.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/AppConnectorsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/AppConnectorsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/AppConnectorsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.CreateAppGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.DeleteAppGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.GetAppGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.GeneratedSnippets/AppGatewaysServiceClient.ListAppGatewaysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.Snippets/AppGatewaysServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1.Snippets/AppGatewaysServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/AppGatewaysServiceClient.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/AppGatewaysServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/AppGatewaysServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/AppGatewaysServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.CreateClientGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.DeleteClientGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.GetClientGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysSnippet.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.GeneratedSnippets/ClientGatewaysServiceClient.ListClientGatewaysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.Snippets/ClientGatewaysServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1.Snippets/ClientGatewaysServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ClientGatewaysServiceClient.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ClientGatewaysServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ClientGatewaysServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ClientGatewaysServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ApproveQueryTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.CreateQueryTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteQueryTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetQueryTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.GetSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListQueryTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSharedResourceSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.ListSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RefreshSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.RevokeSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubmitQueryTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateQueryTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.Snippets/AnalyticsHubServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.Snippets/AnalyticsHubServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/AnalyticsHubServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/AnalyticsHubServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/AnalyticshubResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/AnalyticshubResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.CreateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.DeleteConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.ListConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.GeneratedSnippets/ConnectionServiceClient.UpdateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.Snippets/ConnectionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1.Snippets/ConnectionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ConnectionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.CreateListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.DeleteListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.GetListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListDataExchangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListListingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.ListOrgDataExchangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.SubscribeListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateDataExchangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.GeneratedSnippets/AnalyticsHubServiceClient.UpdateListingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.Snippets/AnalyticsHubServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1.Snippets/AnalyticsHubServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/AnalyticsHubServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/AnalyticsHubServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/DataexchangeResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/DataexchangeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.RenameDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.Snippets/DataPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1.Snippets/DataPolicyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/DataPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/DataPolicyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/DatapolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/DatapolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.CreateDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.DeleteDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.ListDataPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.GeneratedSnippets/DataPolicyServiceClient.UpdateDataPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.Snippets/DataPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1.Snippets/DataPolicyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/DataPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/DataPolicyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/DatapolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/DatapolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CheckValidCredsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.CreateTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.DeleteTransferRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.EnrollDataSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.EnrollDataSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.EnrollDataSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.EnrollDataSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.GetTransferRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListDataSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferLogsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ListTransferRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.ScheduleTransferRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.StartManualTransferRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.StartManualTransferRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.StartManualTransferRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.StartManualTransferRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UnenrollDataSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UnenrollDataSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UnenrollDataSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UnenrollDataSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.GeneratedSnippets/DataTransferServiceClient.UpdateTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/DataTransferServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1.Snippets/DataTransferServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DataTransferServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DatatransferResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/DatatransferResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/TransferResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1/TransferResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.CreateMigrationWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.DeleteMigrationWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationSubtaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.GetMigrationWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationSubtasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.ListMigrationWorkflowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.GeneratedSnippets/MigrationServiceClient.StartMigrationWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.Snippets/MigrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2.Snippets/MigrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/MigrationEntitiesResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/MigrationEntitiesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/MigrationServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/MigrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/MigrationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/MigrationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateCapacityCommitmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.CreateReservationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteCapacityCommitmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.DeleteReservationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.FailoverReservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.FailoverReservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.FailoverReservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.FailoverReservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetBiReservationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetCapacityCommitmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.GetReservationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListAssignmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListCapacityCommitmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.ListReservationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MergeCapacityCommitmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.MoveAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAllAssignmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SearchAssignmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.SplitCapacityCommitmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateBiReservationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateCapacityCommitmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.GeneratedSnippets/ReservationServiceClient.UpdateReservationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.Snippets/ReservationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1.Snippets/ReservationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationServiceClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ReservationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.CreateReadSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.ReadRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.ReadRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.ReadRowsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.ReadRowsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.ReadRowsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.ReadRowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.SplitReadStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.SplitReadStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.SplitReadStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryReadClient.SplitReadStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.AppendRowsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.AppendRowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.BatchCommitWriteStreamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.CreateWriteStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FinalizeWriteStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.FlushRowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamSnippet.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.GeneratedSnippets/BigQueryWriteClient.GetWriteStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.Snippets/BigQueryReadClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.Snippets/BigQueryReadClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.Snippets/BigQueryWriteClientSnippets.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1.Snippets/BigQueryWriteClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryReadClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryWriteClient.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/BigQueryWriteClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StorageResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StorageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StreamResourceNames.g.cs
+++ b/apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1/StreamResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateAppProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateLogicalViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.CreateMaterializedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfile2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteAppProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteLogicalViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.DeleteMaterializedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetAppProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetLogicalViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.GetMaterializedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListAppProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListHotTabletsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListLogicalViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.ListMaterializedViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.PartialUpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateAppProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateLogicalViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableInstanceAdminClient.UpdateMaterializedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencySnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CheckConsistencySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CopyBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateAuthorizedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateSchemaBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableFromSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.CreateTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteAuthorizedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSchemaBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DeleteTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DropRowRangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DropRowRangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DropRowRangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.DropRowRangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GenerateConsistencyTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetAuthorizedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSchemaBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.GetTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListAuthorizedViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSchemaBundlesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListSnapshotsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ListTablesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.ModifyColumnFamiliesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.RestoreTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.RestoreTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.RestoreTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.RestoreTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.SnapshotTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UndeleteTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateAuthorizedViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateSchemaBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.GeneratedSnippets/BigtableTableAdminClient.UpdateTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableInstanceAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableInstanceAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableTableAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2.Snippets/BigtableTableAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableInstanceAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/BigtableTableAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/TableResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2/TableResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRow2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.CheckAndMutateRowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQuery2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ExecuteQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitions2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.GenerateInitialChangeStreamPartitionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRow2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRows2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.MutateRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarm2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PingAndWarmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQuery2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.PrepareQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStream2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadChangeStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRow2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadModifyWriteRowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRows2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.ReadRowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2Snippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeys2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.GeneratedSnippets/BigtableServiceApiClient.SampleRowKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/BigtableServiceApiClientSnippets.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2.Snippets/BigtableServiceApiClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableResourceNames.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/BigtableServiceApiClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.CreateBudgetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.GetBudgetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.ListBudgetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.Snippets/BudgetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1.Snippets/BudgetServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetModelResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetServiceClient.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/BudgetServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.CreateBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.DeleteBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.GetBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.ListBudgetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.GeneratedSnippets/BudgetServiceClient.UpdateBudgetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.Snippets/BudgetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1.Snippets/BudgetServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetModelResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetServiceClient.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/BudgetServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount1Snippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount2Snippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccount2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.CreateBillingAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetBillingAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.GetProjectBillingInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts1Snippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts2Snippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccounts2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListBillingAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.ListProjectBillingInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.MoveBillingAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.MoveBillingAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.MoveBillingAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.MoveBillingAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateBillingAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudBillingClient.UpdateProjectBillingInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusSnippet.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.GeneratedSnippets/CloudCatalogClient.ListSkusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudBillingClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudBillingClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudCatalogClientSnippets.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1.Snippets/CloudCatalogClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudBillingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/CloudCatalogResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.CreateAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.DeleteAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.GetPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.ListAttestorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdateAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicySnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/BinauthzManagementServiceV1Client.UpdatePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/SystemPolicyV1Client.GetSystemPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/ValidationHelperV1Client.ValidateAttestationOccurrenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/ValidationHelperV1Client.ValidateAttestationOccurrenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/ValidationHelperV1Client.ValidateAttestationOccurrenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.GeneratedSnippets/ValidationHelperV1Client.ValidateAttestationOccurrenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/BinauthzManagementServiceV1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/BinauthzManagementServiceV1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/SystemPolicyV1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/SystemPolicyV1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/ValidationHelperV1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1.Snippets/ValidationHelperV1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/BinauthzManagementServiceV1Client.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/BinauthzManagementServiceV1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/SystemPolicyV1Client.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/SystemPolicyV1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ValidationHelperV1Client.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1/ValidationHelperV1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.CreateAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.DeleteAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.GetPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.ListAttestorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdateAttestorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicySnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/BinauthzManagementServiceV1Beta1Client.UpdatePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicySnippet.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.GeneratedSnippets/SystemPolicyV1Beta1Client.GetSystemPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/BinauthzManagementServiceV1Beta1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/BinauthzManagementServiceV1Beta1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/SystemPolicyV1Beta1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1.Snippets/SystemPolicyV1Beta1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/BinauthzManagementServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/BinauthzManagementServiceV1Beta1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/SystemPolicyV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1/SystemPolicyV1Beta1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportForecastsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportForecastsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportForecastsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportForecastsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportReservationsUsageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportReservationsUsageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportReservationsUsageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportReservationsUsageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportUsageHistoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportUsageHistoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportUsageHistoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.ExportUsageHistoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryForecastsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryForecastsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryForecastsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryForecastsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryReservationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryUsageHistoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryUsageHistoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryUsageHistoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.GeneratedSnippets/UsageServiceClient.QueryUsageHistoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.Snippets/UsageServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta.Snippets/UsageServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/UsageServiceClient.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/UsageServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/UsageServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.CapacityPlanner.V1Beta/Google.Cloud.CapacityPlanner.V1Beta/UsageServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateIssuanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntrySnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateDnsAuthorizationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.CreateTrustConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateIssuanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntrySnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteDnsAuthorizationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.DeleteTrustConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateIssuanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntrySnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetDnsAuthorizationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.GetTrustConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateIssuanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificateMapsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListCertificatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListDnsAuthorizationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.ListTrustConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntrySnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateDnsAuthorizationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigSnippet.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.GeneratedSnippets/CertificateManagerClient.UpdateTrustConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.Snippets/CertificateManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1.Snippets/CertificateManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/CertificateIssuanceConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/CertificateIssuanceConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/CertificateManagerClient.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/CertificateManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/CertificateManagerResourceNames.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/CertificateManagerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/TrustConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1/TrustConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.FetchReportResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.ListReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.RunReportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.RunReportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.RunReportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelReportsServiceClient.RunReportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ActivateEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ActivateEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ActivateEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ActivateEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CancelEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CancelEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CancelEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CancelEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeOfferRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeOfferRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeOfferRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeOfferRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeRenewalSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeRenewalSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeRenewalSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ChangeRenewalSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CheckCloudIdentityAccountsExistRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CheckCloudIdentityAccountsExistRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CheckCloudIdentityAccountsExistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CheckCloudIdentityAccountsExistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateChannelPartnerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.CreateEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteChannelPartnerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.DeleteCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetChannelPartnerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.GetEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ImportCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ImportCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ImportCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ImportCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListChannelPartnerRepricingConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomerRepricingConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListCustomersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementChangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListEntitlementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListOffersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListOffersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListOffersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListOffersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableOffersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableOffersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableOffersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableOffersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableSkusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableSkusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableSkusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListPurchasableSkusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupBillableSkusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkuGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSkusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSubscribersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSubscribersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSubscribersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListSubscribersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableOffersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableOffersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableOffersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableOffersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableSkusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableSkusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableSkusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ListTransferableSkusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.LookupOfferRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.LookupOfferRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.LookupOfferRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.LookupOfferRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ProvisionCloudIdentityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ProvisionCloudIdentityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ProvisionCloudIdentityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.ProvisionCloudIdentityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.QueryEligibleBillingAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.QueryEligibleBillingAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.QueryEligibleBillingAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.QueryEligibleBillingAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.RegisterSubscriberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.RegisterSubscriberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.RegisterSubscriberRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.RegisterSubscriberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.StartPaidServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.StartPaidServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.StartPaidServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.StartPaidServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.SuspendEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.SuspendEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.SuspendEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.SuspendEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsToGoogleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsToGoogleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsToGoogleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.TransferEntitlementsToGoogleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UnregisterSubscriberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UnregisterSubscriberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UnregisterSubscriberRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UnregisterSubscriberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateChannelPartnerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRepricingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.GeneratedSnippets/CloudChannelServiceClient.UpdateCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/CloudChannelReportsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/CloudChannelReportsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/CloudChannelServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1.Snippets/CloudChannelServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/BillingAccountsResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/BillingAccountsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ChannelPartnerLinksResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ChannelPartnerLinksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CloudChannelReportsServiceClient.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CloudChannelReportsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CloudChannelServiceClient.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CloudChannelServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CustomersResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/CustomersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/EntitlementChangesResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/EntitlementChangesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/EntitlementsResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/EntitlementsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/OffersResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/OffersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ProductsResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ProductsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ReportsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ReportsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/RepricingResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/RepricingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/SubscriberEventResourceNames.g.cs
+++ b/apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1/SubscriberEventResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.CreateDataAccessScopeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.DeleteDataAccessScopeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.GetDataAccessScopeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.ListDataAccessScopesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/DataAccessControlServiceClient.UpdateDataAccessScopeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.CreateWatchlistSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.DeleteWatchlistSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.GetWatchlistSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.ListWatchlistsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/EntityServiceClient.UpdateWatchlistSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/InstanceServiceClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.CreateReferenceListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.GetReferenceListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.ListReferenceListsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/ReferenceListServiceClient.UpdateReferenceListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRetrohuntSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.CreateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.DeleteRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRetrohuntSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRetrohuntsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRuleRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.ListRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.GeneratedSnippets/RuleServiceClient.UpdateRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/DataAccessControlServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/DataAccessControlServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/EntityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/EntityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/InstanceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/InstanceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/ReferenceListServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/ReferenceListServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/RuleServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1.Snippets/RuleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/DataAccessControlResourceNames.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/DataAccessControlResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/DataAccessControlServiceClient.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/DataAccessControlServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/EntityResourceNames.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/EntityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/EntityServiceClient.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/EntityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/InstanceServiceClient.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/InstanceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/ReferenceListResourceNames.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/ReferenceListResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/ReferenceListServiceClient.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/ReferenceListServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/RuleResourceNames.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/RuleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/RuleServiceClient.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/RuleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Chronicle.V1/Google.Cloud.Chronicle.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ApproveBuildSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuild2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuildRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuildRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuildRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CancelBuildRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuild2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTrigger2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateBuildTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.CreateWorkerPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTrigger2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteBuildTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.DeleteWorkerPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuild2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTrigger2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetBuildTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetDefaultServiceAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.GetWorkerPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildTriggersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListBuildsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ListWorkerPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ReceiveTriggerWebhookRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ReceiveTriggerWebhookRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ReceiveTriggerWebhookRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.ReceiveTriggerWebhookRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuild2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuildRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuildRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuildRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RetryBuildRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.RunBuildTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateBuildTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.GeneratedSnippets/CloudBuildClient.UpdateWorkerPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.Snippets/CloudBuildClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1.Snippets/CloudBuildClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/CloudBuildClient.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/CloudBuildClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/CloudbuildResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/CloudbuildResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.BatchCreateRepositoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.CreateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.DeleteRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchGitRefsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchLinkableRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchLinkableRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchLinkableRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchLinkableRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.FetchReadWriteTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.GetRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.ListRepositoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.GeneratedSnippets/RepositoryManagerClient.UpdateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.Snippets/RepositoryManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2.Snippets/RepositoryManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/CloudbuildResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/CloudbuildResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/RepositoriesResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/RepositoriesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/RepositoryManagerClient.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/RepositoryManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.Snippets/CloudControlsPartnerCoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.Snippets/CloudControlsPartnerCoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.Snippets/CloudControlsPartnerMonitoringClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1.Snippets/CloudControlsPartnerMonitoringClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/AccessApprovalRequestsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/AccessApprovalRequestsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CloudControlsPartnerCoreClient.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CloudControlsPartnerCoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CloudControlsPartnerMonitoringClient.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CloudControlsPartnerMonitoringClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CoreResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CustomerWorkloadsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CustomerWorkloadsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CustomersResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/CustomersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/EkmConnectionsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/EkmConnectionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/PartnerPermissionsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/PartnerPermissionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/PartnersResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/PartnersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/ViolationsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1/ViolationsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.CreateCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.DeleteCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetEkmConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetPartnerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.GetWorkloadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListAccessApprovalRequestsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListCustomersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.ListWorkloadsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerCoreClient.UpdateCustomerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.GetViolationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.GeneratedSnippets/CloudControlsPartnerMonitoringClient.ListViolationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.Snippets/CloudControlsPartnerCoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.Snippets/CloudControlsPartnerCoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.Snippets/CloudControlsPartnerMonitoringClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta.Snippets/CloudControlsPartnerMonitoringClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/AccessApprovalRequestsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/AccessApprovalRequestsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CloudControlsPartnerCoreClient.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CloudControlsPartnerCoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CloudControlsPartnerMonitoringClient.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CloudControlsPartnerMonitoringClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CoreResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CustomerWorkloadsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CustomerWorkloadsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CustomersResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/CustomersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/EkmConnectionsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/EkmConnectionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/PartnerPermissionsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/PartnerPermissionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/PartnersResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/PartnersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/ViolationsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta/ViolationsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ApplyConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ApplyConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ApplyConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ApplyConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CommitConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CommitConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CommitConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CommitConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ConvertConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ConvertConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ConvertConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ConvertConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateConversionWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMappingRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreateMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.CreatePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteConversionWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMappingRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeleteMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DeletePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeConversionWorkspaceRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeConversionWorkspaceRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeConversionWorkspaceRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeConversionWorkspaceRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeDatabaseEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeDatabaseEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeDatabaseEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.DescribeDatabaseEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.FetchStaticIpsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateSshScriptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateSshScriptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateSshScriptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateSshScriptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateTcpProxyScriptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateTcpProxyScriptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateTcpProxyScriptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GenerateTcpProxyScriptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetConversionWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMappingRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.GetPrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ImportMappingRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ImportMappingRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ImportMappingRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ImportMappingRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConnectionProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListConversionWorkspacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMappingRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListMigrationJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ListPrivateConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.PromoteMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.PromoteMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.PromoteMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.PromoteMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RestartMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RestartMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RestartMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RestartMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ResumeMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ResumeMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ResumeMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.ResumeMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RollbackConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RollbackConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RollbackConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.RollbackConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SearchBackgroundJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SearchBackgroundJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SearchBackgroundJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SearchBackgroundJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SeedConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SeedConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SeedConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.SeedConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StartMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StartMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StartMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StartMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StopMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StopMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StopMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.StopMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateConversionWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.UpdateMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.VerifyMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.VerifyMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.VerifyMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.GeneratedSnippets/DataMigrationServiceClient.VerifyMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.Snippets/DataMigrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1.Snippets/DataMigrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ClouddmsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ClouddmsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ClouddmsResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ClouddmsResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ConversionworkspaceResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ConversionworkspaceResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/DataMigrationServiceClient.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/DataMigrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.Snippets/CloudQuotasClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1.Snippets/CloudQuotasClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/CloudQuotasClient.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/CloudQuotasClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/CloudquotasResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/CloudquotasResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreference2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.CreateQuotaPreferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.GetQuotaPreferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaInfosSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.ListQuotaPreferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/CloudQuotasClient.UpdateQuotaPreferenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.GetQuotaAdjusterSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.GeneratedSnippets/QuotaAdjusterSettingsManagerClient.UpdateQuotaAdjusterSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.Snippets/CloudQuotasClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.Snippets/CloudQuotasClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.Snippets/QuotaAdjusterSettingsManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta.Snippets/QuotaAdjusterSettingsManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/CloudQuotasClient.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/CloudQuotasClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/CloudquotasResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/CloudquotasResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/QuotaAdjusterSettingsManagerClient.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/QuotaAdjusterSettingsManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/QuotaAdjusterSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/QuotaAdjusterSettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.CreateFrameworkAuditSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GenerateFrameworkAuditScopeReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.GetFrameworkAuditSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/AuditClient.ListFrameworkAuditsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.CalculateEffectiveCmEnrollmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/CmEnrollmentServiceClient.UpdateCmEnrollmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateCloudControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.CreateFrameworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteCloudControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.DeleteFrameworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetCloudControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.GetFrameworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListCloudControlsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.ListFrameworksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateCloudControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/ConfigClient.UpdateFrameworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.CreateFrameworkDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.DeleteFrameworkDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetCloudControlDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.GetFrameworkDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListCloudControlDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/DeploymentClient.ListFrameworkDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.AggregateFrameworkComplianceReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.FetchFrameworkComplianceReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListControlComplianceSummariesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFindingSummariesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesSnippet.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.GeneratedSnippets/MonitoringClient.ListFrameworkComplianceSummariesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/AuditClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/AuditClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/CmEnrollmentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/CmEnrollmentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/ConfigClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/ConfigClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/DeploymentClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/DeploymentClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/MonitoringClientSnippets.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1.Snippets/MonitoringClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/AuditClient.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/AuditClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/AuditResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/AuditResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/CmEnrollmentServiceClient.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/CmEnrollmentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/CmEnrollmentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/CmEnrollmentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/ConfigClient.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/ConfigClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/ConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/ConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/DeploymentClient.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/DeploymentClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/DeploymentResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/DeploymentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/MonitoringClient.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/MonitoringClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/MonitoringResourceNames.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/MonitoringResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.CloudSecurityCompliance.V1/Google.Cloud.CloudSecurityCompliance.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.CancelOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.CancelOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.CancelOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.CancelOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.GetOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ListOrdersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ModifyOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ModifyOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ModifyOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.ModifyOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.PlaceOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.PlaceOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.PlaceOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/ConsumerProcurementServiceClient.PlaceOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.AssignSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.EnumerateLicensedUsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.GetLicensePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UnassignSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolSnippet.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.GeneratedSnippets/LicenseManagementServiceClient.UpdateLicensePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets/ConsumerProcurementServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets/ConsumerProcurementServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets/LicenseManagementServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1.Snippets/LicenseManagementServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ConsumerProcurementServiceClient.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ConsumerProcurementServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/LicenseManagementServiceClient.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/LicenseManagementServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/LicenseManagementServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/LicenseManagementServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/OrderResourceNames.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/OrderResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ProcurementServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ProcurementServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AcceleratorTypesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.MoveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AddressesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AdviceClient.CalendarModeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/AutoscalersClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.AddSignedUrlKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSignedUrlKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetEdgeSecurityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendBucketsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AddSignedUrlKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSignedUrlKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetEffectiveSecurityPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetHealthSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.ListUsableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetEdgeSecurityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.SetSecurityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/BackendServicesClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/CrossSiteNetworksClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DiskTypesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AddResourcePoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkInsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.BulkSetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.CreateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.RemoveResourcePoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.ResizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StartAsyncReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopAsyncReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.StopGroupAsyncReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/DisksClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ExternalVpnGatewaysClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.AddRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.CloneRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAssociationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.MoveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.RemoveRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallPoliciesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FirewallsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ForwardingRulesClient.SetTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.CancelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/FutureReservationsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.MoveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalAddressesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalForwardingRulesClient.SetTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.AttachNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.DetachNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalNetworkEndpointGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOperationsClient.WaitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalOrganizationOperationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/GlobalPublicDelegatedPrefixesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/HealthChecksClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImageFamilyViewsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.DeprecateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetFromFamilySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ImagesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.CancelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagerResizeRequestsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AbandonInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ApplyUpdatesToInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.CreateInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeletePerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListErrorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListManagedInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListPerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchPerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.RecreateInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.ResumeInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetInstanceTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SetTargetPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StartInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.StopInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.SuspendInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupManagersClient.UpdatePerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AddInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.RemoveInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.SetNamedPortsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceGroupsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceSettingsServiceClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstanceTemplatesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddAccessConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddNetworkInterfaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AddResourcePoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.AttachDiskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.BulkInsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAccessConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteNetworkInterfaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.DetachDiskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetEffectiveFirewallsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetGuestAttributesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetScreenshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSerialPortOutputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentitySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetShieldedInstanceIdentitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListReferrersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.PerformMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.RemoveResourcePoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ReportHostAsFaultySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.ResumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SendDiagnosticInterruptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDeletionProtectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetDiskAutoDeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMachineTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetMinCpuPlatformSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetNameSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSchedulingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetSecurityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetServiceAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetShieldedInstanceIntegrityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SetTagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SimulateMaintenanceEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StartWithEncryptionKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.StopSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.SuspendSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAccessConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateDisplayDeviceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateNetworkInterfaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateShieldedInstanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstancesClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InstantSnapshotsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetOperationalStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentGroupsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectAttachmentsClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.CreateMembersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetOperationalStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectGroupsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectLocationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectRemoteLocationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetDiagnosticsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetMacsecConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/InterconnectsClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicenseCodesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/LicensesClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineImagesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/MachineTypesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkAttachmentsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEdgeSecurityServicesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.AttachNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.DetachNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkEndpointGroupsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddPacketMirroringRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AddRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.CloneRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetPacketMirroringRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchPacketMirroringRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemovePacketMirroringRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.RemoveRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkFirewallPoliciesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworkProfilesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.AddPeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetEffectiveFirewallsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListPeeringRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RemovePeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.RequestRemovePeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.SwitchToCustomModeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NetworksClient.UpdatePeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AddNodesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteNodesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListNodesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.PerformMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SetNodeTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.SimulateMaintenanceEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeGroupsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTemplatesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/NodeTypesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.AddRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.CopyRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAssociationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListPreconfiguredExpressionSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.MoveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/OrganizationSecurityPoliciesClient.RemoveRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PacketMirroringsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PreviewFeaturesClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnHostSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.DisableXpnResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnHostSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.EnableXpnResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnHostSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.GetXpnResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.ListXpnHostsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveDiskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.MoveInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCloudArmorTierSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetCommonInstanceMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetDefaultNetworkTierSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ProjectsClient.SetUsageExportBucketSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.AnnounceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicAdvertisedPrefixesClient.WithdrawSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.AnnounceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/PublicDelegatedPrefixesClient.WithdrawSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionAutoscalersClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetHealthSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.ListUsableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.SetSecurityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionBackendServicesClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionCommitmentsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDiskTypesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.AddResourcePoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.BulkInsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.CreateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.RemoveResourcePoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.ResizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StartAsyncReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopAsyncReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.StopGroupAsyncReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionDisksClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthCheckServicesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionHealthChecksClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.AbandonInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ApplyUpdatesToInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.CreateInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeletePerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListErrorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListManagedInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListPerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchPerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.RecreateInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.ResumeInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetInstanceTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SetTargetPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StartInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.StopInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.SuspendInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupManagersClient.UpdatePerInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.SetNamedPortsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceGroupsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstanceTemplatesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstancesClient.BulkInsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionInstantSnapshotsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.AttachNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.DetachNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListNetworkEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkEndpointGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.AddRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.CloneRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetEffectiveFirewallsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveAssociationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.RemoveRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNetworkFirewallPoliciesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionNotificationEndpointsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionOperationsClient.WaitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.AddRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.RemoveRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSecurityPoliciesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslCertificatesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListAvailableFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionSslPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpProxiesClient.SetUrlMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetSslCertificatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetHttpsProxiesClient.SetUrlMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionTargetTcpProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionUrlMapsClient.ValidateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionZonesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RegionsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.PerformMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationBlocksClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.PerformMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.ReportFaultySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationSubBlocksClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.PerformMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.ResizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ReservationsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ResourcePoliciesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteRoutePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatIpInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetNatMappingInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRoutePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetRouterStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListBgpRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListRoutePoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchRoutePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.PreviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateRoutePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutersClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/RoutesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AddRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListPreconfiguredExpressionSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.RemoveRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SecurityPoliciesClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ServiceAttachmentsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotSettingsServiceClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SnapshotsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslCertificatesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListAvailableFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SslPoliciesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolTypesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListDisksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/StoragePoolsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ExpandIpCidrRangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.ListUsableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.SetPrivateIpGoogleAccessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/SubnetworksClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetGrpcProxiesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpProxiesClient.SetUrlMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetCertificateMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetQuicOverrideSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslCertificatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetSslPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetHttpsProxiesClient.SetUrlMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.SetSecurityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetInstancesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddHealthCheckSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AddInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetHealthSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveHealthCheckSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.RemoveInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.SetSecurityPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetPoolsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetBackendServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetCertificateMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetProxyHeaderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslCertificatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetSslProxiesClient.SetSslPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetBackendServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetTcpProxiesClient.SetProxyHeaderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/TargetVpnGatewaysClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.InvalidateCacheSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.UpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/UrlMapsClient.ValidateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.GetStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnGatewaysClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.AggregatedListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/VpnTunnelsClient.SetLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.InsertSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/WireGroupsClient.PatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.DeleteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZoneOperationsClient.WaitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.GetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListSnippet.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.GeneratedSnippets/ZonesClient.ListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AcceleratorTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AcceleratorTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AddressesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AddressesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AdviceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AdviceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AutoscalersClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/AutoscalersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/BackendBucketsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/BackendBucketsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/BackendServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/BackendServicesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/CrossSiteNetworksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/CrossSiteNetworksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/DiskTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/DiskTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/DisksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/DisksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ExternalVpnGatewaysClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ExternalVpnGatewaysClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/FirewallPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/FirewallPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/FirewallsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/FirewallsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ForwardingRulesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ForwardingRulesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/FutureReservationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/FutureReservationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalAddressesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalAddressesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalForwardingRulesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalForwardingRulesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalNetworkEndpointGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalNetworkEndpointGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalOperationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalOperationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalOrganizationOperationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalOrganizationOperationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalPublicDelegatedPrefixesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/GlobalPublicDelegatedPrefixesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/HealthChecksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/HealthChecksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ImageFamilyViewsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ImageFamilyViewsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ImagesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ImagesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceGroupManagerResizeRequestsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceGroupManagerResizeRequestsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceGroupManagersClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceGroupManagersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceTemplatesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstanceTemplatesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstancesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstancesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstantSnapshotsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InstantSnapshotsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectAttachmentGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectAttachmentGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectAttachmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectAttachmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectLocationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectLocationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectRemoteLocationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectRemoteLocationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/InterconnectsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/LicenseCodesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/LicenseCodesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/LicensesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/LicensesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/MachineImagesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/MachineImagesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/MachineTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/MachineTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkAttachmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkAttachmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkEdgeSecurityServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkEdgeSecurityServicesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkEndpointGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkEndpointGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkFirewallPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkFirewallPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkProfilesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworkProfilesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NetworksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NodeGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NodeGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NodeTemplatesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NodeTemplatesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NodeTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/NodeTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/OrganizationSecurityPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/OrganizationSecurityPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PacketMirroringsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PacketMirroringsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PreviewFeaturesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PreviewFeaturesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ProjectsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ProjectsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PublicAdvertisedPrefixesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PublicAdvertisedPrefixesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PublicDelegatedPrefixesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/PublicDelegatedPrefixesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionAutoscalersClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionAutoscalersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionBackendServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionBackendServicesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionCommitmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionCommitmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionDiskTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionDiskTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionDisksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionDisksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionHealthCheckServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionHealthCheckServicesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionHealthChecksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionHealthChecksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstanceGroupManagersClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstanceGroupManagersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstanceGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstanceGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstanceTemplatesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstanceTemplatesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstancesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstancesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstantSnapshotsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionInstantSnapshotsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionNetworkEndpointGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionNetworkEndpointGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionNetworkFirewallPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionNetworkFirewallPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionNotificationEndpointsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionNotificationEndpointsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionOperationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionOperationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionSecurityPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionSecurityPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionSslCertificatesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionSslCertificatesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionSslPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionSslPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionTargetHttpProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionTargetHttpProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionTargetHttpsProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionTargetHttpsProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionTargetTcpProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionTargetTcpProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionUrlMapsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionUrlMapsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionZonesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionZonesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RegionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ReservationBlocksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ReservationBlocksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ReservationSubBlocksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ReservationSubBlocksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ReservationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ReservationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ResourcePoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ResourcePoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RoutersClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RoutersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RoutesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/RoutesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SecurityPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SecurityPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ServiceAttachmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ServiceAttachmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SnapshotSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SnapshotSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SnapshotsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SnapshotsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SslCertificatesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SslCertificatesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SslPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SslPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/StoragePoolTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/StoragePoolTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/StoragePoolsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/StoragePoolsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SubnetworksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/SubnetworksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetGrpcProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetGrpcProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetHttpProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetHttpProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetHttpsProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetHttpsProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetInstancesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetInstancesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetPoolsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetPoolsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetSslProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetSslProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetTcpProxiesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetTcpProxiesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetVpnGatewaysClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/TargetVpnGatewaysClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/UrlMapsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/UrlMapsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/VpnGatewaysClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/VpnGatewaysClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/VpnTunnelsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/VpnTunnelsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/WireGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/WireGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ZoneOperationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ZoneOperationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ZonesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.Snippets/ZonesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AcceleratorTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AcceleratorTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AddressesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AddressesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AdviceClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AdviceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AutoscalersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/AutoscalersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendBucketsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendBucketsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/BackendServicesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ComputeEnumConstants.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ComputeEnumConstants.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ComputeLroAdaptation.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ComputeLroAdaptation.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/CrossSiteNetworksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/CrossSiteNetworksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DiskTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DiskTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DisksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/DisksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ExternalVpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ExternalVpnGatewaysClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FirewallsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ForwardingRulesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ForwardingRulesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FutureReservationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/FutureReservationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalAddressesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalAddressesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalForwardingRulesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalForwardingRulesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalNetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalNetworkEndpointGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOperationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOrganizationOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalOrganizationOperationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalPublicDelegatedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/GlobalPublicDelegatedPrefixesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/HealthChecksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/HealthChecksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImageFamilyViewsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImageFamilyViewsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImagesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ImagesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagerResizeRequestsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagerResizeRequestsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupManagersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceSettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceTemplatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstanceTemplatesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstancesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstantSnapshotsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InstantSnapshotsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectAttachmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectLocationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectLocationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectRemoteLocationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectRemoteLocationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/InterconnectsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicenseCodesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicenseCodesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicensesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/LicensesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineImagesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineImagesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/MachineTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkAttachmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkAttachmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEdgeSecurityServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEdgeSecurityServicesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkEndpointGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkFirewallPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkFirewallPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkProfilesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworkProfilesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NetworksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTemplatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTemplatesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/NodeTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/OrganizationSecurityPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/OrganizationSecurityPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PacketMirroringsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PacketMirroringsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PreviewFeaturesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PreviewFeaturesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ProjectsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ProjectsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicAdvertisedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicAdvertisedPrefixesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicDelegatedPrefixesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/PublicDelegatedPrefixesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionAutoscalersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionAutoscalersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionBackendServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionBackendServicesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionCommitmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionCommitmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDiskTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDiskTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDisksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionDisksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthCheckServicesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthCheckServicesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthChecksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionHealthChecksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupManagersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupManagersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceTemplatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstanceTemplatesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstancesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstantSnapshotsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionInstantSnapshotsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkEndpointGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkEndpointGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkFirewallPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNetworkFirewallPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNotificationEndpointsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionNotificationEndpointsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionOperationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSecurityPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSecurityPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslCertificatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslCertificatesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionSslPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpsProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetHttpsProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetTcpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionTargetTcpProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionUrlMapsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionUrlMapsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionZonesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionZonesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RegionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationBlocksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationBlocksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationSubBlocksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationSubBlocksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ReservationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ResourcePoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ResourcePoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutersClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/RoutesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SecurityPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SecurityPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceAttachmentsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceAttachmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotSettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SnapshotsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslCertificatesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslCertificatesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SslPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/StoragePoolTypesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/StoragePoolTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/StoragePoolsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/StoragePoolsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SubnetworksClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/SubnetworksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetGrpcProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetGrpcProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpsProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetHttpsProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetInstancesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetInstancesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetPoolsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetPoolsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetSslProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetSslProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetTcpProxiesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetTcpProxiesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetVpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/TargetVpnGatewaysClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/UrlMapsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/UrlMapsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnGatewaysClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnGatewaysClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnTunnelsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/VpnTunnelsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/WireGroupsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/WireGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZoneOperationsClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZoneOperationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZonesClient.g.cs
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/ZonesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialGkeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialGkeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialGkeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialGkeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialSpaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialSpaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialSpaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.GeneratedSnippets/ConfidentialComputingClient.VerifyConfidentialSpaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.Snippets/ConfidentialComputingClientSnippets.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1.Snippets/ConfidentialComputingClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ConfidentialComputingClient.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ConfidentialComputingClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.CreateChallengeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.GeneratedSnippets/ConfidentialComputingClient.VerifyAttestationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.Snippets/ConfidentialComputingClientSnippets.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1.Snippets/ConfidentialComputingClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ConfidentialComputingClient.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ConfidentialComputingClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreateDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.CreatePreviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeletePreviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.DeleteStatefileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportDeploymentStatefileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportDeploymentStatefileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportDeploymentStatefileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportDeploymentStatefileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportLockInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportPreviewResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportPreviewResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportPreviewResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportPreviewResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportRevisionStatefileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportRevisionStatefileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportRevisionStatefileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ExportRevisionStatefileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetPreviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceChangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceDriftSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.GetTerraformVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ImportStatefileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListPreviewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceChangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourceDriftsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.ListTerraformVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.LockDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UnlockDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.GeneratedSnippets/ConfigClient.UpdateDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.Snippets/ConfigClientSnippets.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1.Snippets/ConfigClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ConfigClient.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ConfigClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.CreateVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.GetVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListReleasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ListVariantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.Snippets/ConfigDeliveryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1.Snippets/ConfigDeliveryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/ConfigDeliveryClient.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/ConfigDeliveryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/ConfigDeliveryResourceNames.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/ConfigDeliveryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1/Google.Cloud.ConfigDelivery.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.AbortRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.CreateVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.DeleteVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.GetVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListFleetPackagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListReleasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListResourceBundlesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListRolloutsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ListVariantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.ResumeRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.SuspendRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateFleetPackageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateResourceBundleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantSnippet.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.GeneratedSnippets/ConfigDeliveryClient.UpdateVariantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.Snippets/ConfigDeliveryClientSnippets.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta.Snippets/ConfigDeliveryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/ConfigDeliveryClient.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/ConfigDeliveryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/ConfigDeliveryResourceNames.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/ConfigDeliveryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ConfigDelivery.V1Beta/Google.Cloud.ConfigDelivery.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.CreateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.DeleteConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSchemaMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetConnectorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetGlobalSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetProviderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.GetRuntimeConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListConnectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListProvidersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeActionSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.ListRuntimeEntitySchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.RefreshConnectionSchemaMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.GeneratedSnippets/ConnectorsClient.UpdateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.Snippets/ConnectorsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1.Snippets/ConnectorsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectionResourceNames.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectorResourceNames.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectorVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectorVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectorsClient.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ConnectorsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ProviderResourceNames.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ProviderResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/RuntimeResourceNames.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/RuntimeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/SettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1/SettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkAnalyzeConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDeleteConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkDownloadFeedbackLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.BulkUploadFeedbackLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateIssueModelStatsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CalculateStatsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateAnalysisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateFeedbackLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreatePhraseMatcherSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaQuestionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateQaScorecardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.CreateViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteAnalysisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteFeedbackLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteIssueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeletePhraseMatcherSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaQuestionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteQaScorecardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeleteViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployQaScorecardRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.DeployQaScorecardRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportInsightsDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ExportIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetAnalysisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetEncryptionSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetFeedbackLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetIssueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetPhraseMatcherSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaQuestionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetQaScorecardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.GetViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ImportIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.IngestConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.InitializeEncryptionSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAllFeedbackLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListAnalysisRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListFeedbackLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssueModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListIssuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListPhraseMatchersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaQuestionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListQaScorecardsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.ListViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.QueryMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.QueryMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.QueryMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.QueryMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.TuneQaScorecardRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployQaScorecardRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployQaScorecardRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UndeployQaScorecardRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateAnalysisRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateFeedbackLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateIssueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdatePhraseMatcherSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaQuestionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateQaScorecardSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UpdateViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UploadConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UploadConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UploadConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.GeneratedSnippets/ContactCenterInsightsClient.UploadConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.Snippets/ContactCenterInsightsClientSnippets.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1.Snippets/ContactCenterInsightsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ContactCenterInsightsClient.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ContactCenterInsightsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ContactCenterInsightsResourceNames.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ContactCenterInsightsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperation2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CancelOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CheckAutopilotCompatibilityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CheckAutopilotCompatibilityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CheckAutopilotCompatibilityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CheckAutopilotCompatibilityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotation2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteIPRotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteNodePoolUpgradeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteNodePoolUpgradeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteNodePoolUpgradeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CompleteNodePoolUpgradeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateCluster2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePool2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.CreateNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteCluster2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePool2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.DeleteNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchClusterUpgradeInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.FetchNodePoolUpgradeInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetCluster2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetJSONWebKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetJSONWebKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetJSONWebKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetJSONWebKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePool2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperation2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.GetServerConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClusters2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePools2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListNodePoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperations2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListUsableSubnetworksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListUsableSubnetworksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListUsableSubnetworksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.ListUsableSubnetworksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgrade2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgradeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgradeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgradeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.RollbackNodePoolUpgradeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetAddonsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbac2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbacRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbacRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbacRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLegacyAbacRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocations2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLocationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingService2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetLoggingServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicy2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMaintenancePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMasterAuthRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMasterAuthRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMasterAuthRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMasterAuthRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringService2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetMonitoringServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicy2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNetworkPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolAutoscalingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolAutoscalingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolAutoscalingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolAutoscalingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolManagementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolManagementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolManagementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolManagementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolSizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolSizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolSizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.SetNodePoolSizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotation2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.StartIPRotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateCluster2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster1Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster2Snippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMaster2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMasterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMasterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMasterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateMasterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.GeneratedSnippets/ClusterManagerClient.UpdateNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/ClusterManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1.Snippets/ClusterManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ClusterServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.BatchSearchLinkProcessesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.BatchSearchLinkProcessesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.BatchSearchLinkProcessesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.BatchSearchLinkProcessesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateLineageEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.CreateRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteLineageEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.DeleteRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetLineageEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.GetRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListLineageEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListProcessesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ListRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.ProcessOpenLineageRunEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.SearchLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.SearchLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.SearchLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.SearchLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.GeneratedSnippets/LineageClient.UpdateRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.Snippets/LineageClientSnippets.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1.Snippets/LineageClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/LineageClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/LineageClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/LineageResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/LineageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntrySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.CreateTagTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntrySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.DeleteTagTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroup2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntrySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.GetTagTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ImportEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ImportEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ImportEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ImportEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListEntryGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ListTagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.LookupEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.LookupEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.LookupEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.LookupEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryContactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryContactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryContactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryContactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryOverviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryOverviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryOverviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ModifyEntryOverviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ReconcileTagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ReconcileTagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ReconcileTagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.ReconcileTagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldEnumValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RenameTagTemplateFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveEffectiveConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveEffectiveConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveEffectiveConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.RetrieveEffectiveConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SearchCatalogSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntrySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.StarEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntrySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UnstarEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry1Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry2Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntry2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup1Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup2Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroup2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag1Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag2Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTag2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate1Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate2Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplate2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2Snippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateField2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/DataCatalogClient.UpdateTagTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreatePolicyTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.CreateTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeletePolicyTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.DeleteTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetPolicyTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.GetTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListPolicyTagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.ListTaxonomiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdatePolicyTagSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerClient.UpdateTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ExportTaxonomiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ExportTaxonomiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ExportTaxonomiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ExportTaxonomiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ImportTaxonomiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ImportTaxonomiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ImportTaxonomiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ImportTaxonomiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ReplaceTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ReplaceTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ReplaceTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.GeneratedSnippets/PolicyTagManagerSerializationClient.ReplaceTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/DataCatalogClientSnippets.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/DataCatalogClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/PolicyTagManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/PolicyTagManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/PolicyTagManagerSerializationClientSnippets.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1.Snippets/PolicyTagManagerSerializationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DataCatalogClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DatacatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/DatacatalogResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerSerializationClient.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicyTagManagerSerializationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicytagmanagerResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicytagmanagerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicytagmanagerserializationResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/PolicytagmanagerserializationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TableSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TableSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TagsResourceNames.g.cs
+++ b/apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1/TagsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListAvailableVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.RestartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.RestartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.RestartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.GeneratedSnippets/DataFusionClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.Snippets/DataFusionClientSnippets.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1.Snippets/DataFusionClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/DataFusionClient.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/DataFusionClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/DatafusionResourceNames.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/DatafusionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryDatabaseResourceGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryDatabaseResourceGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryDatabaseResourceGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryDatabaseResourceGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.GeneratedSnippets/DatabaseCenterClient.QueryProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.Snippets/DatabaseCenterClientSnippets.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta.Snippets/DatabaseCenterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta/DatabaseCenterClient.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta/DatabaseCenterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DatabaseCenter.V1Beta/Google.Cloud.DatabaseCenter.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/FlexTemplatesServiceClient.LaunchFlexTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/FlexTemplatesServiceClient.LaunchFlexTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/FlexTemplatesServiceClient.LaunchFlexTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/FlexTemplatesServiceClient.LaunchFlexTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.AggregatedListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.AggregatedListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.AggregatedListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.AggregatedListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CheckActiveJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CheckActiveJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CheckActiveJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CheckActiveJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.SnapshotJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.SnapshotJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.SnapshotJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.SnapshotJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.UpdateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.UpdateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.UpdateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/JobsV1Beta3Client.UpdateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MessagesV1Beta3Client.ListJobMessagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MessagesV1Beta3Client.ListJobMessagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MessagesV1Beta3Client.ListJobMessagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MessagesV1Beta3Client.ListJobMessagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobExecutionDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobExecutionDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobExecutionDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobExecutionDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetJobMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetStageExecutionDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetStageExecutionDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetStageExecutionDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/MetricsV1Beta3Client.GetStageExecutionDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.DeleteSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.DeleteSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.GetSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.GetSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.GetSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.GetSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.ListSnapshotsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.ListSnapshotsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.ListSnapshotsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/SnapshotsV1Beta3Client.ListSnapshotsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.CreateJobFromTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.CreateJobFromTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.CreateJobFromTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.CreateJobFromTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.GetTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.GetTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.GetTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.GetTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.LaunchTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.LaunchTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.LaunchTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.GeneratedSnippets/TemplatesServiceClient.LaunchTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/FlexTemplatesServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/FlexTemplatesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/JobsV1Beta3ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/JobsV1Beta3ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/MessagesV1Beta3ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/MessagesV1Beta3ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/MetricsV1Beta3ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/MetricsV1Beta3ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/SnapshotsV1Beta3ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/SnapshotsV1Beta3ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/TemplatesServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3.Snippets/TemplatesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/FlexTemplatesServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/FlexTemplatesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/JobsV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/JobsV1Beta3Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MessagesV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MessagesV1Beta3Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MetricsV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/MetricsV1Beta3Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/SnapshotsV1Beta3Client.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/SnapshotsV1Beta3Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/TemplatesServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3/TemplatesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateCompilationResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.CreateWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.DeleteWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetCompilationResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkflowInvocationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.GetWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListCompilationResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListReleaseConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListRepositoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ListWorkspacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.MoveFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.WriteFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.WriteFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.WriteFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.GeneratedSnippets/DataformClient.WriteFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.Snippets/DataformClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1.Snippets/DataformClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/DataformClient.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/DataformClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/DataformResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/DataformResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataform.V1/Google.Cloud.Dataform.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CancelWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitRepositoryChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CommitWorkspaceChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ComputeRepositoryAccessTokenStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateCompilationResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkflowInvocationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.CreateWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkflowInvocationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.DeleteWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileDiffRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchFileGitStatusesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchGitAheadBehindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRemoteBranchesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.FetchRepositoryHistoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetCompilationResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkflowInvocationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.GetWorkspaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.InstallNpmPackagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListCompilationResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListReleaseConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListRepositoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkflowInvocationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ListWorkspacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MakeDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.MoveFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PullGitCommitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.PushGitCommitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryCompilationResultActionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryDirectoryContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryRepositoryDirectoryContentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.QueryWorkflowInvocationActionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ReadRepositoryFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.RemoveFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.ResetWorkspaceChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.SearchFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateReleaseConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateRepositorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.UpdateWorkflowConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.WriteFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.WriteFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.WriteFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.GeneratedSnippets/DataformClient.WriteFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.Snippets/DataformClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1.Snippets/DataformClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/DataformClient.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/DataformClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/DataformResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/DataformResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryCategorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.CreateGlossaryTermSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryCategorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.DeleteGlossaryTermSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryCategorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.GetGlossaryTermSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossariesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryCategoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.ListGlossaryTermsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategorySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryCategorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/BusinessGlossaryServiceClient.UpdateGlossaryTermSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CancelMetadataJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateAspectTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateEntryTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.CreateMetadataJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteAspectTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.DeleteEntryTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetAspectTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetEntryTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.GetMetadataJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListAspectTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListEntryTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.ListMetadataJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.LookupEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.LookupEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.LookupEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.LookupEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.SearchEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateAspectTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CatalogServiceClient.UpdateEntryTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.CreateEncryptionConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.DeleteEncryptionConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.GetEncryptionConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.ListEncryptionConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/CmekServiceClient.UpdateEncryptionConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.CreateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.DeleteContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.ListContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/ContentServiceClient.UpdateContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.CreateDataScanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.DeleteDataScanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GenerateDataQualityRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.GetDataScanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScanJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.ListDataScansSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.RunDataScanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataScanServiceClient.UpdateDataScanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.CreateDataTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.DeleteDataTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.GetDataTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributeBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataAttributesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.ListDataTaxonomiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataAttributeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataTaxonomyServiceClient.UpdateDataTaxonomySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CancelJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateLakeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.CreateZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteLakeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.DeleteZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetLakeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.GetZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetActionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListEnvironmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakeActionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListLakesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListTasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZoneActionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.ListZonesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.RunTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateLakeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/DataplexServiceClient.UpdateZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntitySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreateEntitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.CreatePartitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntitySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeleteEntitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.DeletePartitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntitySnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetEntitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.GetPartitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListEntitiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.ListPartitionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.UpdateEntityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.UpdateEntityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.UpdateEntityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.GeneratedSnippets/MetadataServiceClient.UpdateEntityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/BusinessGlossaryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/BusinessGlossaryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/CatalogServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/CatalogServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/CmekServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/CmekServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/ContentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/ContentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/DataScanServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/DataScanServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/DataTaxonomyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/DataTaxonomyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/DataplexServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/DataplexServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/MetadataServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1.Snippets/MetadataServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/AnalyzeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/AnalyzeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/BusinessGlossaryResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/BusinessGlossaryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/BusinessGlossaryServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/BusinessGlossaryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CatalogResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CatalogServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CatalogServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CmekResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CmekResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CmekServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/CmekServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ContentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ContentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ContentServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ContentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataDiscoveryResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataDiscoveryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataQualityResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataQualityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataScanServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataScanServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataTaxonomyResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataTaxonomyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataTaxonomyServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataTaxonomyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataplexServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DataplexServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DatascansResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/DatascansResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/LogsResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/LogsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/MetadataResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/MetadataResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/MetadataServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/MetadataServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ProcessingResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ProcessingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/TasksResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1/TasksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicyResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.CreateAutoscalingPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.DeleteAutoscalingPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.GetAutoscalingPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.ListAutoscalingPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/AutoscalingPolicyServiceClient.UpdateAutoscalingPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.CreateBatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.DeleteBatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.GetBatchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/BatchControllerClient.ListBatchesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.DiagnoseClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClusters2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StartClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StartClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StartClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StartClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StopClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StopClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StopClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.StopClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/ClusterControllerClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.CancelJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobs2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.SubmitJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.UpdateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.UpdateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.UpdateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/JobControllerClient.UpdateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.CreateNodeGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.GetNodeGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/NodeGroupControllerClient.ResizeNodeGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.CreateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.DeleteSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.GetSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionControllerClient.TerminateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.CreateSessionTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.DeleteSessionTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.GetSessionTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.ListSessionTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/SessionTemplateControllerClient.UpdateSessionTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.CreateWorkflowTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.DeleteWorkflowTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.GetWorkflowTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateInlineWorkflowTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplate2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.InstantiateWorkflowTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.ListWorkflowTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.GeneratedSnippets/WorkflowTemplateServiceClient.UpdateWorkflowTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/AutoscalingPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/AutoscalingPolicyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/BatchControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/BatchControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/ClusterControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/ClusterControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/JobControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/JobControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/NodeGroupControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/NodeGroupControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/SessionControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/SessionControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/SessionTemplateControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/SessionTemplateControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/WorkflowTemplateServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1.Snippets/WorkflowTemplateServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPoliciesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPoliciesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/AutoscalingPolicyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/BatchControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/BatchControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/BatchesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/BatchesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClusterControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClustersResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ClustersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/JobControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/NodeGroupControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/NodeGroupControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/NodeGroupsResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/NodeGroupsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionTemplateControllerClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionTemplateControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionTemplatesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionTemplatesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SessionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SharedResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/SharedResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplateServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplatesResourceNames.g.cs
+++ b/apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1/WorkflowTemplatesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.CreateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.CreateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.CreateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.CreateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.DeleteIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.DeleteIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ExportEntitiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.GetIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.GetIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.GetIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.GetIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ImportEntitiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ListIndexesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ListIndexesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ListIndexesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.GeneratedSnippets/DatastoreAdminClient.ListIndexesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.Snippets/DatastoreAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1.Snippets/DatastoreAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/DatastoreAdminClient.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/DatastoreAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.AllocateIdsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.BeginTransactionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit1Snippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit2Snippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.Commit2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.CommitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.CommitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.CommitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.CommitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.LookupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.ReserveIdsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RollbackSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunAggregationQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunAggregationQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunAggregationQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunAggregationQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.GeneratedSnippets/DatastoreClient.RunQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1.Snippets/DatastoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/DatastoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.CreateStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DeleteStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.FetchStaticIpsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.GetStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamObjectsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.ListStreamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.LookupStreamObjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.LookupStreamObjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.LookupStreamObjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.LookupStreamObjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.RunStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.RunStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.RunStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.RunStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StartBackfillJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.StopBackfillJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.GeneratedSnippets/DatastreamClient.UpdateStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.Snippets/DatastreamClientSnippets.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.Snippets/DatastreamClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/DatastreamClient.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/DatastreamClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/DatastreamResourceNames.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/DatastreamResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/DatastreamResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/DatastreamResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreatePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.CreateStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeletePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DeleteStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.DiscoverConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchErrorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchErrorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchErrorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchErrorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.FetchStaticIpsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetPrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.GetStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListConnectionProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListPrivateConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.ListStreamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateConnectionProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamSnippet.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.GeneratedSnippets/DatastreamClient.UpdateStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.Snippets/DatastreamClientSnippets.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1.Snippets/DatastreamClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamClient.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamResourceNames.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/DatastreamResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AbandonReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.AdvanceRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ApproveRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelAutomationRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CancelRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateAutomationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateCustomTargetTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeliveryPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateDeployPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.CreateTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteAutomationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteCustomTargetTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeliveryPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteDeployPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.DeleteTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetAutomationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetCustomTargetTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeliveryPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetDeployPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetJobRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.GetTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.IgnoreJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListAutomationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListCustomTargetTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeliveryPipelinesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListDeployPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListJobRunsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListReleasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListRolloutsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.ListTargetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RetryJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.RollbackTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.TerminateJobRunSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateAutomationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateCustomTargetTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeliveryPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateDeployPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetSnippet.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.GeneratedSnippets/CloudDeployClient.UpdateTargetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.Snippets/CloudDeployClientSnippets.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1.Snippets/CloudDeployClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/CloudDeployClient.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/CloudDeployClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/CloudDeployResourceNames.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/CloudDeployResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.ExportSBOMRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.ExportSBOMRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.ExportSBOMRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.ExportSBOMRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummarySnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.GetVulnerabilityOccurrencesSummarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.GeneratedSnippets/ContainerAnalysisClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.Snippets/ContainerAnalysisClientSnippets.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1.Snippets/ContainerAnalysisClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContainerAnalysisClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContaineranalysisResourceNames.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ContaineranalysisResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateAccountConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.CreateGitRepositoryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteAccountConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteGitRepositoryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteSelfSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.DeleteUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchAccessTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitHubInstallationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchGitRefsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchLinkableGitRepositoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchReadWriteTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.FetchSelfSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetAccountConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.GetGitRepositoryLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListAccountConnectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListGitRepositoryLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.ListUsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateAccountConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/DeveloperConnectClient.UpdateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.CreateInsightsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.DeleteInsightsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.GetInsightsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.ListInsightsConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.UpdateInsightsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.UpdateInsightsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.UpdateInsightsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.GeneratedSnippets/InsightsConfigServiceClient.UpdateInsightsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.Snippets/DeveloperConnectClientSnippets.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.Snippets/DeveloperConnectClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.Snippets/InsightsConfigServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1.Snippets/InsightsConfigServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/DeveloperConnectClient.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/DeveloperConnectClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/DeveloperConnectResourceNames.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/DeveloperConnectResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/InsightsConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/InsightsConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/InsightsConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/InsightsConfigServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DeveloperConnect.V1/Google.Cloud.DeveloperConnect.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.AdbConnectSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.AdbConnectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CancelDeviceSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CancelDeviceSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CancelDeviceSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CancelDeviceSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.CreateDeviceSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.GetDeviceSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.ListDeviceSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.GeneratedSnippets/DirectAccessServiceClient.UpdateDeviceSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.Snippets/DirectAccessServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1.Snippets/DirectAccessServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/DirectAccessServiceClient.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/DirectAccessServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DeviceStreaming.V1/Google.Cloud.DeviceStreaming.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.CreateAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.DeleteAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetAgentValidationResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.GetGenerativeSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ListAgentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.UpdateGenerativeSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ValidateAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ValidateAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ValidateAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/AgentsClient.ValidateAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.GetChangelogSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ChangelogsClient.ListChangelogsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.GetDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/DeploymentsClient.ListDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.CreateEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ExportEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ExportEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ExportEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ExportEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.GetEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ImportEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ImportEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ImportEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ImportEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.ListEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeployFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeployFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeployFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.DeployFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.GetEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListContinuousTestResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistorySnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.LookupEnvironmentHistorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.RunContinuousTestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.RunContinuousTestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.RunContinuousTestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.RunContinuousTestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.CreateExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.DeleteExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.GetExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.ListExperimentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StartExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.StopExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/ExperimentsClient.UpdateExperimentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.CreateFlowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.DeleteFlowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ExportFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ExportFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ExportFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ExportFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.GetFlowValidationResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ImportFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ImportFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ImportFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ImportFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ListFlowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.TrainFlowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.UpdateFlowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ValidateFlowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ValidateFlowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ValidateFlowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/FlowsClient.ValidateFlowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.CreateGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.DeleteGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.GetGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.ListGeneratorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/GeneratorsClient.UpdateGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.CreateIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.DeleteIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ExportIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ExportIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ExportIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ExportIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.GetIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ImportIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ImportIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ImportIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ImportIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.ListIntentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/IntentsClient.UpdateIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.CreatePageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.DeletePageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.GetPageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.ListPagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/PagesClient.UpdatePageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.CreateSecuritySettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.DeleteSecuritySettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.GetSecuritySettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.ListSecuritySettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SecuritySettingsServiceClient.UpdateSecuritySettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.FulfillIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.FulfillIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.FulfillIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.FulfillIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.MatchIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.MatchIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.MatchIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.MatchIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.ServerStreamingDetectIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.ServerStreamingDetectIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.StreamingDetectIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.StreamingDetectIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.SubmitAnswerFeedbackRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.SubmitAnswerFeedbackRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.SubmitAnswerFeedbackRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/SessionsClient.SubmitAnswerFeedbackRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchDeleteTestCasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchRunTestCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchRunTestCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchRunTestCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.BatchRunTestCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CalculateCoverageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CalculateCoverageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CalculateCoverageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CalculateCoverageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.CreateTestCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ExportTestCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ExportTestCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ExportTestCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ExportTestCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.GetTestCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ImportTestCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ImportTestCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ImportTestCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ImportTestCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCaseResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.ListTestCasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.RunTestCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.RunTestCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.RunTestCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.RunTestCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TestCasesClient.UpdateTestCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.CreateTransitionRouteGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.DeleteTransitionRouteGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.GetTransitionRouteGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.ListTransitionRouteGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/TransitionRouteGroupsClient.UpdateTransitionRouteGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CompareVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.CreateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.DeleteVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.GetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.ListVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.LoadVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/VersionsClient.UpdateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.CreateWebhookSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.DeleteWebhookSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.GetWebhookSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.ListWebhooksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.GeneratedSnippets/WebhooksClient.UpdateWebhookSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/AgentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/AgentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/ChangelogsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/ChangelogsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/DeploymentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/DeploymentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EntityTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EnvironmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/EnvironmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/ExperimentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/ExperimentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/FlowsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/FlowsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/GeneratorsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/GeneratorsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/IntentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/IntentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/PagesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/PagesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SecuritySettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SecuritySettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SessionEntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SessionEntityTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SessionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/SessionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TestCasesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TestCasesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TransitionRouteGroupsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/TransitionRouteGroupsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/VersionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/VersionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/WebhooksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3.Snippets/WebhooksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AgentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AgentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AgentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AgentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AudioConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/AudioConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ChangelogResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ChangelogResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ChangelogsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ChangelogsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/DeploymentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/DeploymentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/DeploymentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/DeploymentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EntityTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EnvironmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/EnvironmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ExperimentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ExperimentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ExperimentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ExperimentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FlowResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FlowResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FlowsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FlowsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FulfillmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/FulfillmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/GenerativeSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/GenerativeSettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/GeneratorResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/GeneratorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/GeneratorsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/GeneratorsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/IntentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/IntentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/IntentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/IntentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PageResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PagesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/PagesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SecuritySettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SecuritySettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SecuritySettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SecuritySettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionEntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionEntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionEntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionEntityTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/SessionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TestCaseResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TestCaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TestCasesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TestCasesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TransitionRouteGroupResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TransitionRouteGroupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TransitionRouteGroupsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/TransitionRouteGroupsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/VersionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/VersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/VersionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/VersionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/WebhookResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/WebhookResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/WebhooksClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3/WebhooksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.DeleteAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ExportAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SearchAgentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.SetAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AgentsClient.TrainAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.CreateContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteAllContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.DeleteContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.GetContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.ListContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ContextsClient.UpdateContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.CreateConversationDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.DeleteConversationDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.GetConversationDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ImportConversationDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ImportConversationDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ImportConversationDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ImportConversationDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationDatasetsClient.ListConversationDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.CreateConversationModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeleteConversationModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeployConversationModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeployConversationModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeployConversationModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.DeployConversationModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.GetConversationModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.ListConversationModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.UndeployConversationModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.UndeployConversationModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.UndeployConversationModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationModelsClient.UndeployConversationModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CompleteConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.CreateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GenerateSuggestionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.GetConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.IngestContextReferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.ListMessagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummarySnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ConversationsClient.SuggestConversationSummarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.CreateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.DeleteDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ExportDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ExportDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ExportDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ExportDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.GetDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ListDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.ReloadDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/DocumentsClient.UpdateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypes2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.GetFulfillmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.CreateGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.DeleteGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.GetGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.ListGeneratorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/GeneratorsClient.UpdateGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchDeleteIntentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntents2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.DeleteIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.GetIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntents2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContent3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.CreateParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.GetParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.ListParticipantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.StreamingAnalyzeContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.StreamingAnalyzeContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestArticlesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ParticipantsClient.UpdateParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.DetectIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.StreamingDetectIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SessionsClient.StreamingDetectIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.CreateSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.GetSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.ListSipTrunksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.CreateToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.DeleteToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.GetToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.ListToolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/ToolsClient.UpdateToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.CreateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.DeleteVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.GetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.ListVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.GeneratedSnippets/VersionsClient.UpdateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AgentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AnswerRecordsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/AnswerRecordsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ContextsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ContextsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationDatasetsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationDatasetsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationModelsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationModelsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationProfilesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationProfilesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ConversationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/DocumentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/DocumentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EncryptionSpecServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EncryptionSpecServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EntityTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EnvironmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/EnvironmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/FulfillmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/FulfillmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/GeneratorEvaluationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/GeneratorEvaluationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/GeneratorsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/GeneratorsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/IntentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/IntentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/KnowledgeBasesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/KnowledgeBasesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ParticipantsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ParticipantsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SessionEntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SessionEntityTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SessionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SessionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SipTrunksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/SipTrunksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ToolsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/ToolsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/VersionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2.Snippets/VersionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AgentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AnswerRecordResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AnswerRecordResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AnswerRecordsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AnswerRecordsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AudioConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/AudioConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ContextsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationDatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationDatasetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationDatasetsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationDatasetsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationModelResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationModelsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationModelsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationProfileResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationProfileResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationProfilesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationProfilesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ConversationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/DocumentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/DocumentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/DocumentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/DocumentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EncryptionSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EncryptionSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EncryptionSpecServiceClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EncryptionSpecServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EntityTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/EnvironmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/FulfillmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/FulfillmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/FulfillmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/FulfillmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorEvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorEvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorEvaluationsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorEvaluationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/GeneratorsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/IntentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/KnowledgeBaseResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/KnowledgeBaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/KnowledgeBasesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/KnowledgeBasesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ParticipantResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ParticipantResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ParticipantsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ParticipantsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionEntityTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SessionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SipTrunkResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SipTrunkResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SipTrunksClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/SipTrunksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ToolCallResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ToolCallResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ToolResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ToolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ToolsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/ToolsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/VersionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/VersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/VersionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/VersionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/WebhookResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2/WebhookResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.DeleteAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ExportAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.GetValidationResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.ImportAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.RestoreAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SearchAgentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.SetAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AgentsClient.TrainAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.GetAnswerRecordRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.GetAnswerRecordRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.GetAnswerRecordRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.GetAnswerRecordRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.ListAnswerRecordsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/AnswerRecordsClient.UpdateAnswerRecordSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.CreateContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteAllContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.DeleteContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.GetContextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.ListContextsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContext2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ContextsClient.UpdateContextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ClearSuggestionFeatureConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.CreateConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.DeleteConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.GetConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.ListConversationProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.SetSuggestionFeatureConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationProfilesClient.UpdateConversationProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.BatchCreateMessagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CompleteConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.CreateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSuggestionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateStatelessSummaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GenerateSuggestionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.GetConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.IngestContextReferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.ListMessagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SearchKnowledgeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummarySnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ConversationsClient.SuggestConversationSummarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.CreateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.DeleteDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.GetDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ImportDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ListDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.ReloadDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocument2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/DocumentsClient.UpdateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.GetEncryptionSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EncryptionSpecServiceClient.InitializeEncryptionSpecSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchCreateEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchDeleteEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.BatchUpdateEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.CreateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.DeleteEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.GetEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypes2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.ListEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType3Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityType3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EntityTypesClient.UpdateEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentHistoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.GetFulfillmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/FulfillmentsClient.UpdateFulfillmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.CreateGeneratorEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.DeleteGeneratorEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.GetGeneratorEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorEvaluationsClient.ListGeneratorEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.CreateGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.DeleteGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.GetGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.ListGeneratorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/GeneratorsClient.UpdateGeneratorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchDeleteIntentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntents2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.BatchUpdateIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.CreateIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.DeleteIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.GetIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntents2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.ListIntentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent3Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent4Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntent4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/IntentsClient.UpdateIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.CreateKnowledgeBaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.DeleteKnowledgeBaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.GetKnowledgeBaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.ListKnowledgeBasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBase2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/KnowledgeBasesClient.UpdateKnowledgeBaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContent3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.AnalyzeContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.BidiStreamingAnalyzeContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.BidiStreamingAnalyzeContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CompileSuggestionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CompileSuggestionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CompileSuggestionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CompileSuggestionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.CreateParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.GetParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListParticipantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListSuggestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListSuggestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListSuggestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.ListSuggestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.StreamingAnalyzeContentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.StreamingAnalyzeContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestArticlesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestFaqAnswersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestKnowledgeAssistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.SuggestSmartRepliesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ParticipantsClient.UpdateParticipantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.DeletePhoneNumberSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.ListPhoneNumbersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UndeletePhoneNumberSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/PhoneNumbersClient.UpdatePhoneNumberSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.CreateSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.DeleteSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.GetSessionEntityTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.ListSessionEntityTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2Snippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityType2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionEntityTypesClient.UpdateSessionEntityTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.DetectIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.StreamingDetectIntentSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SessionsClient.StreamingDetectIntentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.CreateSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.DeleteSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.GetSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.ListSipTrunksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/SipTrunksClient.UpdateSipTrunkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.CreateToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.DeleteToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.GetToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.ListToolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/ToolsClient.UpdateToolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.CreateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.DeleteVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.GetVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.ListVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.GeneratedSnippets/VersionsClient.UpdateVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/AgentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/AgentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/AnswerRecordsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/AnswerRecordsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ContextsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ContextsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ConversationProfilesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ConversationProfilesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ConversationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ConversationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/DocumentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/DocumentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/EncryptionSpecServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/EncryptionSpecServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/EntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/EntityTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/EnvironmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/EnvironmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/FulfillmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/FulfillmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/GeneratorEvaluationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/GeneratorEvaluationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/GeneratorsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/GeneratorsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/IntentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/IntentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/KnowledgeBasesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/KnowledgeBasesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ParticipantsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ParticipantsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/PhoneNumbersClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/PhoneNumbersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/SessionEntityTypesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/SessionEntityTypesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/SessionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/SessionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/SipTrunksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/SipTrunksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ToolsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/ToolsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/VersionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1.Snippets/VersionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AgentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AgentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AgentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AgentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AnswerRecordResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AnswerRecordResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AnswerRecordsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AnswerRecordsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AudioConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/AudioConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ContextResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ContextResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ContextsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ContextsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationProfileResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationProfileResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationProfilesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationProfilesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ConversationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/DocumentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/DocumentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/DocumentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/DocumentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EncryptionSpecResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EncryptionSpecResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EncryptionSpecServiceClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EncryptionSpecServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EntityTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EnvironmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/EnvironmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/FulfillmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/FulfillmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/FulfillmentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/FulfillmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorEvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorEvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorEvaluationsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorEvaluationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/GeneratorsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/IntentResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/IntentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/IntentsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/IntentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/KnowledgeBaseResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/KnowledgeBaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/KnowledgeBasesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/KnowledgeBasesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ParticipantResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ParticipantResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ParticipantsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ParticipantsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/PhoneNumberResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/PhoneNumberResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/PhoneNumbersClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/PhoneNumbersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionEntityTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionEntityTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionEntityTypesClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionEntityTypesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SessionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SipTrunkResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SipTrunkResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SipTrunksClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/SipTrunksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ToolCallResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ToolCallResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ToolResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ToolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ToolsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/ToolsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/VersionResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/VersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/VersionsClient.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/VersionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/WebhookResourceNames.g.cs
+++ b/apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1/WebhookResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/AssistantServiceClient.StreamAssistRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/AssistantServiceClient.StreamAssistRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.DeleteCmekConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.GetCmekConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.ListCmekConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CmekConfigServiceClient.UpdateCmekConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.CreateControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.DeleteControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.GetControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.ListControlsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ControlServiceClient.UpdateControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.StreamAnswerQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.StreamAnswerQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.GetDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.ListDataStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.CreateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.DeleteDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.GetDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.ListDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/DocumentServiceClient.UpdateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.CreateEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.DeleteEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.GetEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.ListEnginesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/EngineServiceClient.UpdateEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.StreamGenerateGroundedContentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/GroundedGenerationServiceClient.StreamGenerateGroundedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.CreateIdentityMappingStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.DeleteIdentityMappingStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.GetIdentityMappingStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ImportIdentityMappingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ImportIdentityMappingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ImportIdentityMappingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ImportIdentityMappingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.ListIdentityMappingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.PurgeIdentityMappingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.PurgeIdentityMappingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.PurgeIdentityMappingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/IdentityMappingStoreServiceClient.PurgeIdentityMappingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ProjectServiceClient.ProvisionProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RankServiceClient.RankRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RankServiceClient.RankRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RankServiceClient.RankRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RankServiceClient.RankRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchServiceClient.SearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.CreateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.DeleteSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.GetSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SessionServiceClient.UpdateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.BatchUpdateUserLicensesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.BatchUpdateUserLicensesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.BatchUpdateUserLicensesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.BatchUpdateUserLicensesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.GeneratedSnippets/UserLicenseServiceClient.ListUserLicensesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/AssistantServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/AssistantServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/CmekConfigServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/CmekConfigServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/CompletionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/CompletionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ControlServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ControlServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ConversationalSearchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ConversationalSearchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/DataStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/DataStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/DocumentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/DocumentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/EngineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/EngineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/GroundedGenerationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/GroundedGenerationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/IdentityMappingStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/IdentityMappingStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ProjectServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ProjectServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/RankServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/RankServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/RecommendationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/RecommendationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SchemaServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SchemaServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SearchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SearchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SearchTuningServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SearchTuningServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ServingConfigServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/ServingConfigServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SessionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SessionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SiteSearchEngineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/SiteSearchEngineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/UserEventServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/UserEventServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/UserLicenseServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.Snippets/UserLicenseServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AnswerResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AnswerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistAnswerResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistAnswerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistantResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistantResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistantServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistantServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistantServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/AssistantServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ChunkResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ChunkResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CmekConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CmekConfigServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CmekConfigServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CmekConfigServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CompletionServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CompletionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CompletionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CompletionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ControlResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ControlResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ControlServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ControlServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ControlServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ControlServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ConversationResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ConversationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ConversationalSearchServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ConversationalSearchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ConversationalSearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ConversationalSearchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CustomTuningModelResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/CustomTuningModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DataStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DataStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DataStoreServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DataStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DataStoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DataStoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentProcessingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentProcessingConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/DocumentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/EngineResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/EngineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/EngineServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/EngineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/EngineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/EngineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/GroundedGenerationServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/GroundedGenerationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/GroundedGenerationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/GroundedGenerationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/IdentityMappingStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/IdentityMappingStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/IdentityMappingStoreServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/IdentityMappingStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/IdentityMappingStoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/IdentityMappingStoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ImportConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ImportConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ProjectResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ProjectResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ProjectServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ProjectServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ProjectServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ProjectServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/PurgeConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/PurgeConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RankServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RankServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RankServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RankServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RecommendationServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RecommendationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RecommendationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/RecommendationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SchemaResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SchemaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SchemaServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SchemaServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SchemaServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SchemaServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchTuningServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchTuningServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchTuningServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SearchTuningServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServingConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServingConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/ServingConfigServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SessionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SessionServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SessionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SiteSearchEngineResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SiteSearchEngineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SiteSearchEngineServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SiteSearchEngineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SiteSearchEngineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/SiteSearchEngineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserEventResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserEventResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserEventServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserEventServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserEventServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserEventServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserLicenseResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserLicenseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserLicenseServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserLicenseServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserLicenseServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/UserLicenseServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.AdvancedCompleteQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.AdvancedCompleteQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.AdvancedCompleteQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.AdvancedCompleteQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportCompletionSuggestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.ImportSuggestionDenyListEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeCompletionSuggestionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/CompletionServiceClient.PurgeSuggestionDenyListEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.CreateControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.DeleteControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.GetControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.ListControlsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ControlServiceClient.UpdateControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.AnswerQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ConverseConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.CreateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.DeleteSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetAnswerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.GetSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ConversationalSearchServiceClient.UpdateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.CreateDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.DeleteDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.GetDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.ListDataStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DataStoreServiceClient.UpdateDataStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.BatchGetDocumentsMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.CreateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.DeleteDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.GetDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.ListDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.PurgeDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/DocumentServiceClient.UpdateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.CreateEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.DeleteEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.GetEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ListEnginesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.PauseEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.ResumeEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.TuneEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EngineServiceClient.UpdateEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.CreateEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.GetEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/EvaluationServiceClient.ListEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.CheckGroundingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.GenerateGroundedContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.StreamGenerateGroundedContentSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/GroundedGenerationServiceClient.StreamGenerateGroundedContentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ProjectServiceClient.ProvisionProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RankServiceClient.RankRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RankServiceClient.RankRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RankServiceClient.RankRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RankServiceClient.RankRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/RecommendationServiceClient.RecommendRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQueryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQuerySnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.CreateSampleQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQueryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQuerySnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.DeleteSampleQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQueryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQuerySnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.GetSampleQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ImportSampleQueriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ImportSampleQueriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ImportSampleQueriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ImportSampleQueriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.ListSampleQueriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQueryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQueryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQuerySnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQueryServiceClient.UpdateSampleQuerySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.CreateSampleQuerySetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.DeleteSampleQuerySetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.GetSampleQuerySetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.ListSampleQuerySetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SampleQuerySetServiceClient.UpdateSampleQuerySetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.CreateSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.DeleteSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.GetSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.ListSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SchemaServiceClient.UpdateSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchLiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchServiceClient.SearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.ListCustomModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SearchTuningServiceClient.TrainCustomModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.CreateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.DeleteSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.GetSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SessionServiceClient.UpdateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchCreateTargetSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.BatchVerifyTargetSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateSitemapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.CreateTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteSitemapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DeleteTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.DisableAdvancedSiteSearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.EnableAdvancedSiteSearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchDomainVerificationStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.FetchSitemapsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetSiteSearchEngineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.GetTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.ListTargetSitesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.RecrawlUrisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/SiteSearchEngineServiceClient.UpdateTargetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/CompletionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/CompletionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ControlServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ControlServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ConversationalSearchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ConversationalSearchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/DataStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/DataStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/DocumentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/DocumentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/EngineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/EngineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/EvaluationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/EvaluationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/GroundedGenerationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/GroundedGenerationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ProjectServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ProjectServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/RankServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/RankServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/RecommendationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/RecommendationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SampleQueryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SampleQueryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SampleQuerySetServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SampleQuerySetServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SchemaServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SchemaServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SearchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SearchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SearchTuningServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SearchTuningServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ServingConfigServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/ServingConfigServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SessionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SessionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SiteSearchEngineServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/SiteSearchEngineServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/UserEventServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta.Snippets/UserEventServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/AnswerResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/AnswerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ChunkResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ChunkResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CompletionServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CompletionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CompletionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CompletionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ControlResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ControlResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ControlServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ControlServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ControlServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ControlServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ConversationResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ConversationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ConversationalSearchServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ConversationalSearchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ConversationalSearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ConversationalSearchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CustomTuningModelResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/CustomTuningModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DataStoreResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DataStoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DataStoreServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DataStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DataStoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DataStoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentProcessingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentProcessingConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/DocumentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EngineResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EngineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EngineServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EngineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EngineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EngineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EvaluationServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EvaluationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EvaluationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/EvaluationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/GroundedGenerationServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/GroundedGenerationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/GroundedGenerationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/GroundedGenerationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/GroundingResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/GroundingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ImportConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ImportConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ProjectResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ProjectResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ProjectServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ProjectServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ProjectServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ProjectServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/PurgeConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/PurgeConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RankServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RankServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RankServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RankServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RecommendationServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RecommendationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RecommendationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/RecommendationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQueryResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQueryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQueryServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQueryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQueryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQueryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQuerySetResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQuerySetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQuerySetServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQuerySetServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQuerySetServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SampleQuerySetServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SchemaResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SchemaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SchemaServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SchemaServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SchemaServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SchemaServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchTuningServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchTuningServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchTuningServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SearchTuningServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServingConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServingConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServingConfigServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServingConfigServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/ServingConfigServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SessionResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SessionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SessionServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SessionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SiteSearchEngineResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SiteSearchEngineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SiteSearchEngineServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SiteSearchEngineServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SiteSearchEngineServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/SiteSearchEngineServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/UserEventResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/UserEventResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/UserEventServiceClient.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/UserEventServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/UserEventServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta/UserEventServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ActivateJobTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ActivateJobTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ActivateJobTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ActivateJobTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CancelDlpJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CancelDlpJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CancelDlpJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CancelDlpJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDeidentifyTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDiscoveryConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJob2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateDlpJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateInspectTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateJobTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.CreateStoredInfoTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeidentifyContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeidentifyContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeidentifyContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeidentifyContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDeidentifyTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDiscoveryConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteDlpJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteFileStoreDataProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteInspectTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteJobTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteStoredInfoTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.DeleteTableDataProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.FinishDlpJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.FinishDlpJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.FinishDlpJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.FinishDlpJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetColumnDataProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDeidentifyTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDiscoveryConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetDlpJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetFileStoreDataProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetInspectTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetJobTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetProjectDataProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetStoredInfoTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.GetTableDataProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectDlpJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.HybridInspectJobTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.InspectContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.InspectContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.InspectContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.InspectContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListColumnDataProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDeidentifyTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDiscoveryConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListDlpJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListFileStoreDataProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInfoTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListInspectTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListJobTriggersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListProjectDataProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListStoredInfoTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ListTableDataProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.RedactImageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.RedactImageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.RedactImageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.RedactImageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ReidentifyContentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ReidentifyContentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ReidentifyContentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.ReidentifyContentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.SearchConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDeidentifyTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateDiscoveryConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateInspectTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateJobTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.GeneratedSnippets/DlpServiceClient.UpdateStoredInfoTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/DlpServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2.Snippets/DlpServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpResourceNames.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/DlpServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.Snippets/DocumentProcessorServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1.Snippets/DocumentProcessorServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/DocumentProcessorServiceClient.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/DocumentProcessorServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/DocumentProcessorServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/DocumentProcessorServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/EvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/EvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ProcessorResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ProcessorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ProcessorTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ProcessorTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.BatchProcessDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.CreateProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeleteProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DeployProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.DisableProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EnableProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.EvaluateProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.FetchProcessorTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetEvaluationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.GetProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ImportProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListEvaluationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ListProcessorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ProcessDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.ReviewDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.SetDefaultProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.TrainProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentProcessorServiceClient.UndeployProcessorVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.BatchDeleteDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDatasetSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.GetDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ImportDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.ListDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.GeneratedSnippets/DocumentServiceClient.UpdateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.Snippets/DocumentProcessorServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.Snippets/DocumentProcessorServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.Snippets/DocumentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.Snippets/DocumentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DatasetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentProcessorServiceClient.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentProcessorServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentProcessorServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentProcessorServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentServiceClient.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/DocumentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/EvaluationResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/EvaluationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ProcessorResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ProcessorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ProcessorTypeResourceNames.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ProcessorTypeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.DeleteRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ExportRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.GetRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ListRegistrationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RegisterDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.SearchDomainsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.TransferDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.GeneratedSnippets/DomainsClient.UpdateRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.Snippets/DomainsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1.Snippets/DomainsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/DomainsClient.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/DomainsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/DomainsResourceNames.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/DomainsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureContactSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureDnsSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ConfigureManagementSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.DeleteRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ExportRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.GetRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ListRegistrationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RegisterDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.ResetAuthorizationCodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveAuthorizationCodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveRegisterParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.RetrieveTransferParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.SearchDomainsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.TransferDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.GeneratedSnippets/DomainsClient.UpdateRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.Snippets/DomainsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1.Snippets/DomainsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/DomainsClient.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/DomainsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/DomainsResourceNames.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/DomainsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateInterconnectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateRouterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.CreateSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteInterconnectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteRouterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DeleteSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseInterconnectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.DiagnoseRouterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetInterconnectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetRouterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.GetZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.InitializeZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectAttachmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListInterconnectsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListNetworksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListRoutersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListSubnetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.ListZonesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateRouterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.GeneratedSnippets/EdgeNetworkClient.UpdateSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.Snippets/EdgeNetworkClientSnippets.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1.Snippets/EdgeNetworkClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/EdgeNetworkClient.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/EdgeNetworkClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CancelEntityReconciliationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.CreateEntityReconciliationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.DeleteEntityReconciliationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.GetEntityReconciliationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.ListEntityReconciliationJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupPublicKgSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.LookupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchPublicKgSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchSnippet.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.GeneratedSnippets/EnterpriseKnowledgeGraphServiceClient.SearchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.Snippets/EnterpriseKnowledgeGraphServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1.Snippets/EnterpriseKnowledgeGraphServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/EnterpriseKnowledgeGraphServiceClient.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/EnterpriseKnowledgeGraphServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.GetGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorGroupServiceClient.UpdateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.DeleteEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ErrorStatsServiceClient.ListGroupStatsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventSnippet.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.GeneratedSnippets/ReportErrorsServiceClient.ReportErrorEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorGroupServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ErrorStatsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1.Snippets/ReportErrorsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorGroupServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ErrorStatsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ReportErrorsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ComputeContactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ComputeContactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ComputeContactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ComputeContactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.CreateContactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.DeleteContactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.GetContactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.ListContactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.SendTestMessageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.SendTestMessageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.SendTestMessageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.SendTestMessageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactSnippet.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.GeneratedSnippets/EssentialContactsServiceClient.UpdateContactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.Snippets/EssentialContactsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1.Snippets/EssentialContactsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/EssentialContactsServiceClient.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/EssentialContactsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishChannelConnectionEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishChannelConnectionEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishChannelConnectionEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishChannelConnectionEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.GeneratedSnippets/PublisherClient.PublishRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/PublisherClientSnippets.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1.Snippets/PublisherClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/PublisherClient.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/PublisherClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateEnrollmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateGoogleApiSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateMessageBusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreatePipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.CreateTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteEnrollmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteGoogleApiSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteMessageBusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeletePipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.DeleteTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetEnrollmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleApiSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetGoogleChannelConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetMessageBusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetPipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetProviderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.GetTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListChannelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListEnrollmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListGoogleApiSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusEnrollmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListMessageBusesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListPipelinesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListProvidersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.ListTriggersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateEnrollmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleApiSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateGoogleChannelConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateMessageBusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdatePipelineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerSnippet.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.GeneratedSnippets/EventarcClient.UpdateTriggerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.Snippets/EventarcClientSnippets.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1.Snippets/EventarcClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ChannelConnectionResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ChannelConnectionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ChannelResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ChannelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/DiscoveryResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/DiscoveryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EnrollmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EnrollmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EventarcClient.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EventarcClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EventarcResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/EventarcResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/GoogleApiSourceResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/GoogleApiSourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/GoogleChannelConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/GoogleChannelConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/MessageBusResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/MessageBusResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/NetworkConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/NetworkConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/PipelineResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/PipelineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/TriggerResourceNames.g.cs
+++ b/apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1/TriggerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.CreateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.DeleteSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.GetSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.ListSnapshotsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.PromoteReplicaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.PromoteReplicaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.PromoteReplicaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.PromoteReplicaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RestoreInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RestoreInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RestoreInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RestoreInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RevertInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RevertInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RevertInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.RevertInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.GeneratedSnippets/CloudFilestoreManagerClient.UpdateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.Snippets/CloudFilestoreManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1.Snippets/CloudFilestoreManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/CloudFilestoreManagerClient.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/CloudFilestoreManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/CloudFilestoreServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/CloudFilestoreServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateBacktestResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.CreatePredictionResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteBacktestResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeleteModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.DeletePredictionResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportBacktestResultMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportEngineConfigMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportModelMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportPredictionResultMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ExportRegisteredPartiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetBacktestResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetEngineVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.GetPredictionResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ImportRegisteredPartiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListBacktestResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListEngineVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.ListPredictionResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateBacktestResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateEngineConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultSnippet.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.GeneratedSnippets/AMLClient.UpdatePredictionResultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.Snippets/AMLClientSnippets.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1.Snippets/AMLClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/AMLClient.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/AMLClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/BacktestResultResourceNames.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/BacktestResultResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/DatasetResourceNames.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/DatasetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/EngineConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/EngineConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/EngineVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/EngineVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/ModelResourceNames.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/ModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/PredictionResultResourceNames.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/PredictionResultResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.FinancialServices.V1/Google.Cloud.FinancialServices.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.BulkDeleteDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CloneDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CloneDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CloneDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CloneDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.CreateUserCredsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DeleteUserCredsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.DisableUserCredsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.EnableUserCredsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ExportDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.GetUserCredsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ImportDocumentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupSchedulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListFieldsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListIndexesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ListUserCredsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.ResetUserPasswordSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.RestoreDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.RestoreDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.RestoreDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.RestoreDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.GeneratedSnippets/FirestoreAdminClient.UpdateFieldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.Snippets/FirestoreAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1.Snippets/FirestoreAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/BackupResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/BackupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/DatabaseResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/DatabaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FieldResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FieldResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/FirestoreAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/IndexResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/IndexResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/OperationResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/OperationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/ScheduleResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/ScheduleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/SnapshotResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/SnapshotResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/UserCredsResourceNames.g.cs
+++ b/apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1/UserCredsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BatchGetDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BatchGetDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BatchWriteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BatchWriteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BatchWriteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BatchWriteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.BeginTransactionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CommitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CreateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CreateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.CreateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.DeleteDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ExecutePipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ExecutePipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.GetDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.GetDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.GetDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.GetDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListCollectionIdsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListDocumentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListDocumentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListDocumentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListenSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.ListenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.PartitionQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.PartitionQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.PartitionQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.PartitionQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RollbackSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RunAggregationQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RunAggregationQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RunQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.RunQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.UpdateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.WriteSnippet.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.GeneratedSnippets/FirestoreClient.WriteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Snippets/FirestoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1.Snippets/FirestoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/FirestoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CallFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.CreateFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.DeleteFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateDownloadUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateDownloadUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateDownloadUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateDownloadUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateUploadUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateUploadUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateUploadUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GenerateUploadUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.ListFunctionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.ListFunctionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.ListFunctionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.ListFunctionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.GeneratedSnippets/CloudFunctionsServiceClient.UpdateFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.Snippets/CloudFunctionsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1.Snippets/CloudFunctionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/CloudFunctionsServiceClient.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/CloudFunctionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/FunctionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/FunctionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.CreateFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.DeleteFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.GetFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListFunctionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.ListRuntimesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.GeneratedSnippets/FunctionServiceClient.UpdateFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.Snippets/FunctionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2.Snippets/FunctionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/FunctionServiceClient.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/FunctionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/FunctionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/FunctionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.CreateFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.DeleteFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateDownloadUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GenerateUploadUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.GetFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListFunctionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.ListRuntimesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionSnippet.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.GeneratedSnippets/FunctionServiceClient.UpdateFunctionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.Snippets/FunctionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta.Snippets/FunctionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/FunctionServiceClient.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/FunctionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/FunctionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/FunctionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.CreateDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.DeleteDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetAuthorizationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.GetInstallStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.InstallDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ListDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.ReplaceDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.GeneratedSnippets/GSuiteAddOnsClient.UninstallDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.Snippets/GSuiteAddOnsClientSnippets.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1.Snippets/GSuiteAddOnsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/GSuiteAddOnsClient.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/GSuiteAddOnsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/GsuiteaddonsResourceNames.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/GsuiteaddonsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CancelOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateCommentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateHardwareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.CreateZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteHardwareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.DeleteZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntrySnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetChangeLogEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetCommentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetHardwareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetSkuSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.GetZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListChangeLogEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListCommentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListHardwareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListOrdersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSitesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListSkusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.ListZonesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RecordActionOnCommentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.RequestOrderDateChangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SignalZoneStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.SubmitOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateHardwareSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateOrderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateSiteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneSnippet.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.GeneratedSnippets/GDCHardwareManagementClient.UpdateZoneSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.Snippets/GDCHardwareManagementClientSnippets.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha.Snippets/GDCHardwareManagementClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/GDCHardwareManagementClient.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/GDCHardwareManagementClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.CreateDataAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.DeleteDataAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetDataAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListAccessibleDataAgentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.ListDataAgentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataAgentServiceClient.UpdateDataAgentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ChatRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ChatRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.CreateConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.DeleteConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.GetConversationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListConversationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.ListMessagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.QueryDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.QueryDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.QueryDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.GeneratedSnippets/DataChatServiceClient.QueryDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.Snippets/DataAgentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.Snippets/DataAgentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.Snippets/DataChatServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta.Snippets/DataChatServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/ConversationResourceNames.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/ConversationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataAgentResourceNames.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataAgentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataAgentServiceClient.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataAgentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataAgentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataAgentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataChatServiceClient.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataChatServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataChatServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/DataChatServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GeminiDataAnalytics.V1Beta/Google.Cloud.GeminiDataAnalytics.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestorePlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.CreateRestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestorePlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.DeleteRestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupIndexDownloadUrlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestorePlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetRestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.GetVolumeRestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupChannelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlanBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupPlansSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoreChannelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlanBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestorePlansSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListRestoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.ListVolumeRestoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupPlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestorePlanSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreSnippet.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.GeneratedSnippets/BackupForGKEClient.UpdateRestoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.Snippets/BackupForGKEClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1.Snippets/BackupForGKEClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupChannelResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupChannelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupForGKEClient.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupForGKEClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupPlanBindingResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupPlanBindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupPlanResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupPlanResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/BackupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/GkebackupResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/GkebackupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestoreChannelResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestoreChannelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestorePlanBindingResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestorePlanBindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestorePlanResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestorePlanResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestoreResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/RestoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/VolumeResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1/VolumeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.GeneratedSnippets/GatewayControlClient.GenerateCredentialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.GeneratedSnippets/GatewayControlClient.GenerateCredentialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.GeneratedSnippets/GatewayControlClient.GenerateCredentialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.GeneratedSnippets/GatewayControlClient.GenerateCredentialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.Snippets/GatewayControlClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1.Snippets/GatewayControlClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/GatewayControlClient.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/GatewayControlClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.CreateMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.DeleteMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GenerateConnectManifestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GenerateConnectManifestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GenerateConnectManifestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GenerateConnectManifestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.GetMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListFeaturesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.ListMembershipsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateFeatureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.GeneratedSnippets/GkeHubClient.UpdateMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.Snippets/GkeHubClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1.Snippets/GkeHubClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/FeatureResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/FeatureResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/GkeHubClient.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/GkeHubClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/MembershipResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/MembershipResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.CreateMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.DeleteMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateConnectManifestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateConnectManifestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateConnectManifestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateConnectManifestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateExclusivityManifestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateExclusivityManifestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateExclusivityManifestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GenerateExclusivityManifestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.GetMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ListMembershipsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.UpdateMembershipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ValidateExclusivityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ValidateExclusivityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ValidateExclusivityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.GeneratedSnippets/GkeHubMembershipServiceClient.ValidateExclusivityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.Snippets/GkeHubMembershipServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1.Snippets/GkeHubMembershipServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/GkeHubMembershipServiceClient.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/GkeHubMembershipServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/MembershipResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/MembershipResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.CreateAttachedClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.DeleteAttachedClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterAgentTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterAgentTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterAgentTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterAgentTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GenerateAttachedClusterInstallManifestSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.GetAttachedServerConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ImportAttachedClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.ListAttachedClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AttachedClustersClient.UpdateAttachedClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.CreateAwsNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.DeleteAwsNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsAccessTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsAccessTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsAccessTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsAccessTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsClusterAgentTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsClusterAgentTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsClusterAgentTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GenerateAwsClusterAgentTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsJsonWebKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsJsonWebKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsJsonWebKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsJsonWebKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsOpenIdConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsOpenIdConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsOpenIdConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsOpenIdConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.GetAwsServerConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.ListAwsNodePoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.RollbackAwsNodePoolUpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AwsClustersClient.UpdateAwsNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClientSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.CreateAzureNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClientSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.DeleteAzureNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureAccessTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureAccessTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureAccessTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureAccessTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureClusterAgentTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureClusterAgentTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureClusterAgentTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GenerateAzureClusterAgentTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClientSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureJsonWebKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureOpenIdConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.GetAzureServerConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClientsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.ListAzureNodePoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolSnippet.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.GeneratedSnippets/AzureClustersClient.UpdateAzureNodePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/AttachedClustersClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/AttachedClustersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/AwsClustersClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/AwsClustersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/AzureClustersClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1.Snippets/AzureClustersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AttachedClustersClient.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AttachedClustersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AttachedResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AttachedResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AttachedServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AttachedServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AwsClustersClient.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AwsClustersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AwsResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AwsResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AwsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AwsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AzureClustersClient.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AzureClustersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AzureResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AzureResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AzureServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/AzureServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchBenchmarkingDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchBenchmarkingDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchBenchmarkingDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchBenchmarkingDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServerVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServerVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServerVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServerVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelServersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.FetchProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.GenerateOptimizedManifestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.GenerateOptimizedManifestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.GenerateOptimizedManifestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.GeneratedSnippets/GkeInferenceQuickstartClient.GenerateOptimizedManifestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.Snippets/GkeInferenceQuickstartClientSnippets.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1.Snippets/GkeInferenceQuickstartClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1/GkeInferenceQuickstartClient.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1/GkeInferenceQuickstartClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.GkeRecommender.V1/Google.Cloud.GkeRecommender.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.GeneratedSnippets/HypercomputeClusterClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.Snippets/HypercomputeClusterClientSnippets.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta.Snippets/HypercomputeClusterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/HypercomputeClusterClient.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/HypercomputeClusterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/HypercomputeClusterResourceNames.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/HypercomputeClusterResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.HypercomputeCluster.V1Beta/Google.Cloud.HypercomputeCluster.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateRoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateRoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateRoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateRoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.CreateServiceAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteRoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteRoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteRoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteRoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DeleteServiceAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.DisableServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.EnableServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetRoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetRoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetRoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetRoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.GetServiceAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.LintPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.LintPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.LintPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.LintPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListRolesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListRolesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListRolesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListRolesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.ListServiceAccountsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.PatchServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.PatchServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.PatchServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.PatchServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryAuditableServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryAuditableServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryAuditableServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryAuditableServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryGrantableRolesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryTestablePermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryTestablePermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryTestablePermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.QueryTestablePermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignBlobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.SignJwtSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteRoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteRoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteRoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteRoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UndeleteServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateRoleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateRoleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateRoleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateRoleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UpdateServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UploadServiceAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UploadServiceAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UploadServiceAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.GeneratedSnippets/IAMClient.UploadServiceAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.Snippets/IAMClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1.Snippets/IAMClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/IAMClient.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/IAMClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/IamResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/IamResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateAccessTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.GenerateIdTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignBlobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.GeneratedSnippets/IAMCredentialsClient.SignJwtSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.Snippets/IAMCredentialsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1.Snippets/IAMCredentialsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/IAMCredentialsClient.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/IAMCredentialsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.GeneratedSnippets/IAMPolicyClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Snippets/IAMPolicyClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1.Snippets/IAMPolicyClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IAMPolicyClient.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IAMPolicyClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IamPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/IamPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.CreatePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.DeletePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.GetPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.ListPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.UpdatePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.UpdatePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.UpdatePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.GeneratedSnippets/PoliciesClient.UpdatePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.Snippets/PoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2.Snippets/PoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/PoliciesClient.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/PoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.Snippets/PolicyBindingsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.Snippets/PolicyBindingsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.Snippets/PrincipalAccessBoundaryPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3.Snippets/PrincipalAccessBoundaryPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PolicyBindingResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PolicyBindingResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PolicyBindingsClient.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PolicyBindingsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PolicyBindingsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PolicyBindingsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PrincipalAccessBoundaryPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PrincipalAccessBoundaryPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PrincipalAccessBoundaryPoliciesServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PrincipalAccessBoundaryPoliciesServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PrincipalAccessBoundaryPolicyResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/PrincipalAccessBoundaryPolicyResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.V3/Google.Cloud.Iam.V3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.CreatePolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.DeletePolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.GetPolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.ListPolicyBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.SearchTargetPolicyBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PolicyBindingsClient.UpdatePolicyBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.CreatePrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.DeletePrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.GetPrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.ListPrincipalAccessBoundaryPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.SearchPrincipalAccessBoundaryPolicyBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.GeneratedSnippets/PrincipalAccessBoundaryPoliciesClient.UpdatePrincipalAccessBoundaryPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.Snippets/PolicyBindingsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.Snippets/PolicyBindingsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.Snippets/PrincipalAccessBoundaryPoliciesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta.Snippets/PrincipalAccessBoundaryPoliciesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PolicyBindingResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PolicyBindingResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PolicyBindingsClient.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PolicyBindingsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PolicyBindingsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PolicyBindingsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PrincipalAccessBoundaryPoliciesClient.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PrincipalAccessBoundaryPoliciesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PrincipalAccessBoundaryPoliciesServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PrincipalAccessBoundaryPoliciesServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PrincipalAccessBoundaryPolicyResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/PrincipalAccessBoundaryPolicyResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iam.V3Beta/Google.Cloud.Iam.V3Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.CreateTunnelDestGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.DeleteTunnelDestGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIapSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIapSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIapSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetIapSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.GetTunnelDestGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ListTunnelDestGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateIapSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateIapSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateIapSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateIapSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.UpdateTunnelDestGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ValidateIapAttributeExpressionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ValidateIapAttributeExpressionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ValidateIapAttributeExpressionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyAdminServiceClient.ValidateIapAttributeExpressionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateBrandRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateBrandRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateBrandRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateBrandRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateIdentityAwareProxyClientRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateIdentityAwareProxyClientRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateIdentityAwareProxyClientRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.CreateIdentityAwareProxyClientRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.DeleteIdentityAwareProxyClientRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.DeleteIdentityAwareProxyClientRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.DeleteIdentityAwareProxyClientRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.DeleteIdentityAwareProxyClientRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetBrandRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetBrandRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetBrandRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetBrandRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetIdentityAwareProxyClientRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetIdentityAwareProxyClientRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetIdentityAwareProxyClientRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.GetIdentityAwareProxyClientRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListBrandsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListBrandsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListBrandsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListBrandsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListIdentityAwareProxyClientsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListIdentityAwareProxyClientsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListIdentityAwareProxyClientsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ListIdentityAwareProxyClientsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ResetIdentityAwareProxyClientSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ResetIdentityAwareProxyClientSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ResetIdentityAwareProxyClientSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.GeneratedSnippets/IdentityAwareProxyOAuthServiceClient.ResetIdentityAwareProxyClientSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.Snippets/IdentityAwareProxyAdminServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.Snippets/IdentityAwareProxyAdminServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.Snippets/IdentityAwareProxyOAuthServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1.Snippets/IdentityAwareProxyOAuthServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyAdminServiceClient.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyAdminServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyOAuthServiceClient.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/IdentityAwareProxyOAuthServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.CreateEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.DeleteEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.GetEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.GeneratedSnippets/IDSClient.ListEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.Snippets/IDSClientSnippets.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1.Snippets/IDSClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/IDSClient.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/IDSClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/IdsResourceNames.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/IdsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyDashboardServiceClient.ListCryptoKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummarySnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.GetProtectedResourcesSummarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.GeneratedSnippets/KeyTrackingServiceClient.SearchProtectedResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.Snippets/KeyDashboardServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.Snippets/KeyDashboardServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.Snippets/KeyTrackingServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1.Snippets/KeyTrackingServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyDashboardServiceClient.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyDashboardServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyDashboardServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyDashboardServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyTrackingServiceClient.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyTrackingServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyTrackingServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/KeyTrackingServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.GetAutokeyConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.ShowEffectiveAutokeyConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyAdminClient.UpdateAutokeyConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.CreateKeyHandleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.GetKeyHandleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/AutokeyClient.ListKeyHandlesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.CreateEkmConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.GetEkmConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.ListEkmConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.UpdateEkmConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivitySnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/EkmServiceClient.VerifyConnectivitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricDecryptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.AsymmetricSignSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeySnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateCryptoKeyVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.CreateKeyRingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecapsulateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecapsulateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecapsulateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecapsulateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DecryptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.DestroyCryptoKeyVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.EncryptSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GenerateRandomBytesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeySnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetCryptoKeyVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetKeyRingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.GetPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ImportCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ImportCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ImportCryptoKeyVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ImportCryptoKeyVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeyVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListCryptoKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListImportJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.ListKeyRingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacSignSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifySnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.MacVerifySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawDecryptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawDecryptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawDecryptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawDecryptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawEncryptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawEncryptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawEncryptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RawEncryptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.RestoreCryptoKeyVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyPrimaryVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeySnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.GeneratedSnippets/KeyManagementServiceClient.UpdateCryptoKeyVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/AutokeyAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/AutokeyAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/AutokeyClientSnippets.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/AutokeyClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/EkmServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/EkmServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/KeyManagementServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1.Snippets/KeyManagementServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyAdminClient.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyClient.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/AutokeyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/EkmServiceClient.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/EkmServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/EkmServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/EkmServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/KeyManagementServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentiment2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitySentimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntax2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntaxRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntaxRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntaxRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnalyzeSyntaxRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateText2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ClassifyTextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.GeneratedSnippets/LanguageServiceClient.ModerateTextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1.Snippets/LanguageServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/LanguageServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntities2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeEntitiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentiment2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnalyzeSentimentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText1Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText2Snippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateText2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.AnnotateTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ClassifyTextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextSnippet.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.GeneratedSnippets/LanguageServiceClient.ModerateTextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.Snippets/LanguageServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2.Snippets/LanguageServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/LanguageServiceClient.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/LanguageServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.AggregateUsageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.CreateConfigurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeactivateConfigurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.DeleteConfigurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetConfigurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.GetProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListConfigurationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ListProductsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.QueryConfigurationLicenseUsageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.ReactivateConfigurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationSnippet.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.GeneratedSnippets/LicenseManagerClient.UpdateConfigurationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.Snippets/LicenseManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1.Snippets/LicenseManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/ApiEntitiesResourceNames.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/ApiEntitiesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/LicenseManagerClient.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/LicenseManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/LicensemanagerResourceNames.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/LicensemanagerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.LicenseManager.V1/Google.Cloud.LicenseManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets/WorkflowsServiceV2BetaClient.RunPipelineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets/WorkflowsServiceV2BetaClient.RunPipelineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets/WorkflowsServiceV2BetaClient.RunPipelineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.GeneratedSnippets/WorkflowsServiceV2BetaClient.RunPipelineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.Snippets/WorkflowsServiceV2BetaClientSnippets.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta.Snippets/WorkflowsServiceV2BetaClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/WorkflowsServiceV2BetaClient.g.cs
+++ b/apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta/WorkflowsServiceV2BetaClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.GetLocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.GetLocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.GetLocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.GetLocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.ListLocationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.ListLocationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.ListLocationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location.GeneratedSnippets/LocationsClient.ListLocationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location.Snippets/LocationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location.Snippets/LocationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location/LocationsClient.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/LocationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Location/Google.Cloud.Location/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Location/Google.Cloud.Location/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.GetCloudLocationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.ListCloudLocationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsSnippet.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.GeneratedSnippets/CloudLocationFinderClient.SearchCloudLocationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.Snippets/CloudLocationFinderClientSnippets.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1.Snippets/CloudLocationFinderClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/CloudLocationFinderClient.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/CloudLocationFinderClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/CloudLocationResourceNames.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/CloudLocationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.LocationFinder.V1/Google.Cloud.LocationFinder.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CopyLogEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CopyLogEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CopyLogEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CopyLogEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketLongRunningRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketLongRunningRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketLongRunningRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketLongRunningRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateBucketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateExclusionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateSinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.CreateViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteBucketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteBucketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteBucketRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteBucketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteExclusionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteSinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.DeleteViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetBucketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetBucketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetBucketRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetBucketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetCmekSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetCmekSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetCmekSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetCmekSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetExclusionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetLinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetSinkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.GetViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListBucketsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListExclusionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListLinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListSinksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.ListViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UndeleteBucketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UndeleteBucketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UndeleteBucketRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UndeleteBucketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketLongRunningRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketLongRunningRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketLongRunningRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketLongRunningRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateBucketRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateCmekSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateCmekSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateCmekSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateCmekSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateExclusionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSink2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSinkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSinkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSinkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateSinkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/ConfigServiceV2Client.UpdateViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.DeleteLogSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListLogsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListMonitoredResourceDescriptorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListMonitoredResourceDescriptorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListMonitoredResourceDescriptorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.ListMonitoredResourceDescriptorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.TailLogEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.TailLogEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/LoggingServiceV2Client.WriteLogEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.CreateLogMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.DeleteLogMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.GetLogMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.ListLogMetricsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricSnippet.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.GeneratedSnippets/MetricsServiceV2Client.UpdateLogMetricSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/ConfigServiceV2ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/LoggingServiceV2ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2.Snippets/MetricsServiceV2ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ConfigServiceV2Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LogEntryResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LogEntryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingMetricsResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingMetricsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingResourceNames.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/LoggingServiceV2Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/MetricsServiceV2Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ExportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ExportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ExportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ExportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ImportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.GeneratedSnippets/LustreClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.Snippets/LustreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1.Snippets/LustreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/LustreClient.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/LustreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/LustreResourceNames.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/LustreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/TransferResourceNames.g.cs
+++ b/apis/Google.Cloud.Lustre.V1/Google.Cloud.Lustre.V1/TransferResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.Snippets/MaintenanceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1.Snippets/MaintenanceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/MaintenanceClient.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/MaintenanceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/MaintenanceServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/MaintenanceServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1/Google.Cloud.Maintenance.Api.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.GetResourceMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.ListResourceMaintenancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesSnippet.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.GeneratedSnippets/MaintenanceClient.SummarizeMaintenancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.Snippets/MaintenanceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta.Snippets/MaintenanceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/MaintenanceClient.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/MaintenanceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/MaintenanceServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/MaintenanceServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Maintenance.Api.V1Beta/Google.Cloud.Maintenance.Api.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.AttachTrustSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.CreateMicrosoftAdDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DeleteDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.DetachTrustSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.GetDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ListDomainsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ReconfigureTrustSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ResetAdminPasswordSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.UpdateDomainSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.GeneratedSnippets/ManagedIdentitiesServiceClient.ValidateTrustSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.Snippets/ManagedIdentitiesServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1.Snippets/ManagedIdentitiesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ManagedIdentitiesServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntrySnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.AddAclEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateAclSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.CreateTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteAclSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteConsumerGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.DeleteTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetAclSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetConsumerGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.GetTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListAclsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListConsumerGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.ListTopicsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntrySnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.RemoveAclEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateAclSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateConsumerGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaClient.UpdateTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.CreateConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.DeleteConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.GetConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ListConnectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.PauseConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.RestartConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.ResumeConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.StopConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.GeneratedSnippets/ManagedKafkaConnectClient.UpdateConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.Snippets/ManagedKafkaClientSnippets.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.Snippets/ManagedKafkaClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.Snippets/ManagedKafkaConnectClientSnippets.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.Snippets/ManagedKafkaConnectClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaClient.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaConnectClient.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaConnectClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaConnectResourceNames.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaConnectResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaResourceNames.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ManagedKafkaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.GeneratedSnippets/SpeechTranslationServiceClient.StreamingTranslateSpeechSnippet.g.cs
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.GeneratedSnippets/SpeechTranslationServiceClient.StreamingTranslateSpeechSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.Snippets/SpeechTranslationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1.Snippets/SpeechTranslationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/SpeechTranslationServiceClient.g.cs
+++ b/apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1/SpeechTranslationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ApplyParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.GeneratedSnippets/CloudMemcacheClient.UpdateParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.Snippets/CloudMemcacheClientSnippets.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1.Snippets/CloudMemcacheClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/CloudMemcacheClient.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/CloudMemcacheClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/CloudMemcacheResourceNames.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/CloudMemcacheResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplyParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ApplySoftwareUpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.RescheduleMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersSnippet.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.GeneratedSnippets/CloudMemcacheClient.UpdateParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.Snippets/CloudMemcacheClientSnippets.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2.Snippets/CloudMemcacheClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheResourceNames.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/CloudMemcacheResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.BackupInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ExportBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ExportBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ExportBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ExportBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupCollectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupCollectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.RescheduleMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.GeneratedSnippets/MemorystoreClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.Snippets/MemorystoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1.Snippets/MemorystoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/MemorystoreClient.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/MemorystoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/MemorystoreResourceNames.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/MemorystoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.GeneratedSnippets/MemorystoreClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.Snippets/MemorystoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta.Snippets/MemorystoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/MemorystoreClient.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/MemorystoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/MemorystoreResourceNames.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/MemorystoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.Snippets/DataprocMetastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.Snippets/DataprocMetastoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.Snippets/DataprocMetastoreFederationClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1.Snippets/DataprocMetastoreFederationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/DataprocMetastoreClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/DataprocMetastoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/DataprocMetastoreFederationClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/DataprocMetastoreFederationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/MetastoreFederationResourceNames.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/MetastoreFederationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/MetastoreResourceNames.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/MetastoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/DataprocMetastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/DataprocMetastoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/DataprocMetastoreFederationClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha.Snippets/DataprocMetastoreFederationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/DataprocMetastoreClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/DataprocMetastoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/DataprocMetastoreFederationClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/DataprocMetastoreFederationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/MetastoreFederationResourceNames.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/MetastoreFederationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/MetastoreResourceNames.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/MetastoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.AlterMetadataResourceLocationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ExportMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListMetadataImportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.MoveTableToDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.QueryMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RemoveIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.RestoreServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateMetadataImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreClient.UpdateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.CreateFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.DeleteFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.GetFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.ListFederationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationSnippet.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.GeneratedSnippets/DataprocMetastoreFederationClient.UpdateFederationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/DataprocMetastoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/DataprocMetastoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/DataprocMetastoreFederationClientSnippets.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta.Snippets/DataprocMetastoreFederationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/DataprocMetastoreClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/DataprocMetastoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/DataprocMetastoreFederationClient.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/DataprocMetastoreFederationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/MetastoreFederationResourceNames.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/MetastoreFederationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/MetastoreResourceNames.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/MetastoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AddAssetsToGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AggregateAssetsValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AggregateAssetsValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AggregateAssetsValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.AggregateAssetsValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchDeleteAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.BatchUpdateAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportDataFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreatePreferenceSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.CreateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportDataFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeletePreferenceSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.DeleteSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetErrorFrameSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportDataFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetPreferenceSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.GetSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListErrorFramesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportDataFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListImportJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListPreferenceSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ListSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RemoveAssetsFromGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ReportAssetFramesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ReportAssetFramesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ReportAssetFramesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ReportAssetFramesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.RunImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdatePreferenceSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.UpdateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.GeneratedSnippets/MigrationCenterClient.ValidateImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.Snippets/MigrationCenterClientSnippets.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1.Snippets/MigrationCenterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/MigrationCenterClient.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/MigrationCenterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/MigrationcenterResourceNames.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/MigrationcenterResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.CreateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.DeleteTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetFloorSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.GetTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.ListTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.GeneratedSnippets/ModelArmorClient.UpdateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.Snippets/ModelArmorClientSnippets.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1.Snippets/ModelArmorClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/ModelArmorClient.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/ModelArmorClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1/Google.Cloud.ModelArmor.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.CreateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.DeleteTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetFloorSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.GetTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.ListTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeModelResponseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.SanitizeUserPromptRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateFloorSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.GeneratedSnippets/ModelArmorClient.UpdateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.Snippets/ModelArmorClientSnippets.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta.Snippets/ModelArmorClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/ModelArmorClient.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/ModelArmorClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ModelArmor.V1Beta/Google.Cloud.ModelArmor.V1Beta/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicyResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.CreateAlertPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicyResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.DeleteAlertPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicyResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.GetAlertPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.ListAlertPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/AlertPolicyServiceClient.UpdateAlertPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.CreateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.DeleteGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.GetGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupMembersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.ListGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/GroupServiceClient.UpdateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateMetricDescriptorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateServiceTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.CreateTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.DeleteMetricDescriptorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMetricDescriptorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.GetMonitoredResourceDescriptorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMetricDescriptorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListMonitoredResourceDescriptorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/MetricServiceClient.ListTimeSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.CreateNotificationChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.DeleteNotificationChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelDescriptorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.GetNotificationChannelVerificationCodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelDescriptorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.ListNotificationChannelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.SendNotificationChannelVerificationCodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.UpdateNotificationChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/NotificationChannelServiceClient.VerifyNotificationChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/QueryServiceClient.QueryTimeSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/QueryServiceClient.QueryTimeSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/QueryServiceClient.QueryTimeSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/QueryServiceClient.QueryTimeSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceLevelObjectiveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceLevelObjectiveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceLevelObjectiveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServiceLevelObjectivesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceLevelObjectiveSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/ServiceMonitoringServiceClient.UpdateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.CreateSnoozeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.GetSnoozeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.ListSnoozesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/SnoozeServiceClient.UpdateSnoozeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.CreateUptimeCheckConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.DeleteUptimeCheckConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.GetUptimeCheckConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckIpsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckIpsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckIpsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.ListUptimeCheckIpsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.GeneratedSnippets/UptimeCheckServiceClient.UpdateUptimeCheckConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/AlertPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/AlertPolicyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/GroupServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/MetricServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/NotificationChannelServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/NotificationChannelServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/QueryServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/QueryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/ServiceMonitoringServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/ServiceMonitoringServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/SnoozeServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/SnoozeServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/UptimeCheckServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3.Snippets/UptimeCheckServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertPolicyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/AlertServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/GroupServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/MetricServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationChannelServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/NotificationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/QueryServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/QueryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceMonitoringServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/ServiceServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/SnoozeResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/SnoozeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/SnoozeServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/SnoozeServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/SnoozeServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/SnoozeServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeCheckServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3/UptimeServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectorySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateActiveDirectorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateKmsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateQuotaRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateStoragePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.CreateVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectorySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteActiveDirectorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteKmsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteQuotaRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteStoragePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.DeleteVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EncryptVolumesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EncryptVolumesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EncryptVolumesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EncryptVolumesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EstablishPeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EstablishPeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EstablishPeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.EstablishPeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectorySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetActiveDirectorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetKmsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetQuotaRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetStoragePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.GetVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListActiveDirectoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupVaultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListKmsConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListQuotaRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListReplicationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListSnapshotsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListStoragePoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ListVolumesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ResumeReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ResumeReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ResumeReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ResumeReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ReverseReplicationDirectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ReverseReplicationDirectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ReverseReplicationDirectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ReverseReplicationDirectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.RevertVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.RevertVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.RevertVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.RevertVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.StopReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.StopReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.StopReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.StopReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SwitchActiveReplicaZoneRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SwitchActiveReplicaZoneRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SwitchActiveReplicaZoneRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SwitchActiveReplicaZoneRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SyncReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SyncReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SyncReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.SyncReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectorySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateActiveDirectorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateBackupVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateKmsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateQuotaRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateReplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateStoragePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.UpdateVolumeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ValidateDirectoryServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ValidateDirectoryServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ValidateDirectoryServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.ValidateDirectoryServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.VerifyKmsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.VerifyKmsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.VerifyKmsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.GeneratedSnippets/NetAppClient.VerifyKmsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.Snippets/NetAppClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1.Snippets/NetAppClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ActiveDirectoryResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ActiveDirectoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/BackupPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/BackupPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/BackupResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/BackupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/BackupVaultResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/BackupVaultResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/CloudNetappServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/CloudNetappServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/KmsResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/KmsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/NetAppClient.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/NetAppClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/QuotaRuleResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/QuotaRuleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ReplicationResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ReplicationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/SnapshotResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/SnapshotResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/StoragePoolResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/StoragePoolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/VolumeResourceNames.g.cs
+++ b/apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1/VolumeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.CreateServiceConnectionTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.DeleteServiceConnectionTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.GetServiceConnectionTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceClassesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionMapsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.ListServiceConnectionTokensSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/CrossNetworkAutomationServiceClient.UpdateServiceConnectionPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateDestinationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.CreateMulticloudDataTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteDestinationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.DeleteMulticloudDataTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetDestinationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.GetMulticloudDataTransferSupportedServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListDestinationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.ListMulticloudDataTransferSupportedServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateDestinationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/DataTransferServiceClient.UpdateMulticloudDataTransferConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptHubSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.AcceptSpokeUpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.CreateSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.DeleteSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetRouteTableSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.GetSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubSpokesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListHubsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRouteTablesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.ListSpokesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.QueryHubStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectHubSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.RejectSpokeUpdateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/HubServiceClient.UpdateSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.CreateInternalRangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.DeleteInternalRangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.GetInternalRangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.ListInternalRangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/InternalRangeServiceClient.UpdateInternalRangeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.CreatePolicyBasedRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.DeletePolicyBasedRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.GetPolicyBasedRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.GeneratedSnippets/PolicyBasedRoutingServiceClient.ListPolicyBasedRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/CrossNetworkAutomationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/CrossNetworkAutomationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/DataTransferServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/DataTransferServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/HubServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/HubServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/InternalRangeServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/InternalRangeServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/PolicyBasedRoutingServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1.Snippets/PolicyBasedRoutingServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/CrossNetworkAutomationResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/CrossNetworkAutomationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/CrossNetworkAutomationServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/CrossNetworkAutomationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/DataTransferResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/DataTransferResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/DataTransferServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/DataTransferServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/HubResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/HubResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/HubServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/HubServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/InternalRangeResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/InternalRangeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/InternalRangeServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/InternalRangeServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/PolicyBasedRoutingResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/PolicyBasedRoutingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/PolicyBasedRoutingServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/PolicyBasedRoutingServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.CreateSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.DeleteSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.GetSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListHubsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.ListSpokesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateHubSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.GeneratedSnippets/HubServiceClient.UpdateSpokeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets/HubServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1.Snippets/HubServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/HubResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/HubResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/HubServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/HubServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.CreateVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.GetVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.ListVpcFlowLogsConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/OrganizationVpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.CreateConnectivityTestSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.DeleteConnectivityTestSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.GetConnectivityTestSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.ListConnectivityTestsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.RerunConnectivityTestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.RerunConnectivityTestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.RerunConnectivityTestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.RerunConnectivityTestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/ReachabilityServiceClient.UpdateConnectivityTestSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.CreateVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.DeleteVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.GetVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ListVpcFlowLogsConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.QueryOrgVpcFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.QueryOrgVpcFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.QueryOrgVpcFlowLogsConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.QueryOrgVpcFlowLogsConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ShowEffectiveFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ShowEffectiveFlowLogsConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ShowEffectiveFlowLogsConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.ShowEffectiveFlowLogsConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.GeneratedSnippets/VpcFlowLogsServiceClient.UpdateVpcFlowLogsConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/OrganizationVpcFlowLogsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/OrganizationVpcFlowLogsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/ReachabilityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/ReachabilityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/VpcFlowLogsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1.Snippets/VpcFlowLogsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ConnectivityTestResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ConnectivityTestResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/OrganizationVpcFlowLogsServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/OrganizationVpcFlowLogsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ReachabilityResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ReachabilityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ReachabilityServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ReachabilityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/VpcFlowLogsConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/VpcFlowLogsConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/VpcFlowLogsResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/VpcFlowLogsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/VpcFlowLogsServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1/VpcFlowLogsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.CreateDnsThreatDetectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.DeleteDnsThreatDetectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.GetDnsThreatDetectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.ListDnsThreatDetectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/DnsThreatDetectorServiceClient.UpdateDnsThreatDetectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateAuthorizationPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateClientTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.CreateServerTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteAuthorizationPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteClientTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.DeleteServerTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetAuthorizationPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetClientTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.GetServerTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListAuthorizationPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListClientTlsPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.ListServerTlsPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateAuthorizationPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateClientTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.GeneratedSnippets/NetworkSecurityClient.UpdateServerTlsPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.Snippets/DnsThreatDetectorServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.Snippets/DnsThreatDetectorServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.Snippets/NetworkSecurityClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1.Snippets/NetworkSecurityClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/AuthorizationPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/AuthorizationPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ClientTlsPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ClientTlsPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/DnsThreatDetectorResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/DnsThreatDetectorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/DnsThreatDetectorServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/DnsThreatDetectorServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/NetworkSecurityClient.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/NetworkSecurityClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ServerTlsPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ServerTlsPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateAuthzExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbEdgeExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbRouteExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.CreateLbTrafficExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteAuthzExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbEdgeExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbRouteExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.DeleteLbTrafficExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetAuthzExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbEdgeExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbRouteExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.GetLbTrafficExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListAuthzExtensionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbEdgeExtensionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbRouteExtensionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.ListLbTrafficExtensionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateAuthzExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbEdgeExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbRouteExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/DepServiceClient.UpdateLbTrafficExtensionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateEndpointPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateGrpcRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateHttpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateMeshSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateServiceLbPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTcpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateTlsRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.CreateWasmPluginVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteEndpointPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteGrpcRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteHttpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteMeshSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteServiceLbPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTcpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteTlsRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.DeleteWasmPluginVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetEndpointPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewayRouteViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetGrpcRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetHttpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshRouteViewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetMeshSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetServiceLbPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTcpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetTlsRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.GetWasmPluginVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListEndpointPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewayRouteViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGatewaysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListGrpcRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListHttpRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshRouteViewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListMeshesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListServiceLbPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTcpRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListTlsRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.ListWasmPluginsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateEndpointPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewaySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGatewaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateGrpcRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateHttpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateMeshSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicySnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateServiceLbPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTcpRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateTlsRouteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginSnippet.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.GeneratedSnippets/NetworkServicesClient.UpdateWasmPluginSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.Snippets/DepServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.Snippets/DepServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.Snippets/NetworkServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1.Snippets/NetworkServicesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/DepResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/DepResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/DepServiceClient.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/DepServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/EndpointPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/EndpointPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ExtensibilityResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ExtensibilityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/GatewayResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/GatewayResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/GrpcRouteResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/GrpcRouteResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/HttpRouteResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/HttpRouteResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/MeshResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/MeshResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/NetworkServicesClient.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/NetworkServicesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/RouteViewResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/RouteViewResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ServiceBindingResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ServiceBindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ServiceLbPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/ServiceLbPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/TcpRouteResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/TcpRouteResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/TlsRouteResourceNames.g.cs
+++ b/apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1/TlsRouteResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.CreateRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DeleteRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.DiagnoseRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.GetRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ListRuntimesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.RefreshRuntimeTokenInternalSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ReportRuntimeEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.ResetRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StartRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.StopRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.SwitchRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpdateRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/ManagedNotebookServiceClient.UpgradeRuntimeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.CreateScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DeleteScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceHealthSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.GetScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ListSchedulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.TriggerScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.TriggerScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.TriggerScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.TriggerScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceMetadataItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceMetadataItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceMetadataItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateInstanceMetadataItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateShieldedInstanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateShieldedInstanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateShieldedInstanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpdateShieldedInstanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.Snippets/ManagedNotebookServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.Snippets/ManagedNotebookServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.Snippets/NotebookServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1.Snippets/NotebookServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/EnvironmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ExecutionResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ExecutionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ManagedNotebookServiceClient.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ManagedNotebookServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ManagedServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ManagedServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/NotebookServiceClient.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/NotebookServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/RuntimeResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/RuntimeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ScheduleResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ScheduleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.IsInstanceUpgradeableRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListEnvironmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.RegisterInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ReportInstanceInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceAcceleratorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.SetInstanceMachineTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceInternalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.Snippets/NotebookServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1.Snippets/NotebookServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/EnvironmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/EnvironmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/NotebookServiceClient.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/NotebookServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CheckInstanceUpgradabilityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CheckInstanceUpgradabilityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CheckInstanceUpgradabilityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CheckInstanceUpgradabilityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.DiagnoseInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.ResetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.RollbackInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StartInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.StopInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.GeneratedSnippets/NotebookServiceClient.UpgradeInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.Snippets/NotebookServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2.Snippets/NotebookServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/InstanceResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/InstanceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/NotebookServiceClient.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/NotebookServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.BatchOptimizeToursRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.BatchOptimizeToursRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.BatchOptimizeToursRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.BatchOptimizeToursRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.OptimizeToursRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.OptimizeToursRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.OptimizeToursRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.GeneratedSnippets/FleetRoutingClient.OptimizeToursRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.Snippets/FleetRoutingClientSnippets.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1.Snippets/FleetRoutingClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/FleetRoutingClient.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/FleetRoutingClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudExadataInfrastructureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateCloudVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateDbSystemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExadbVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateExascaleDbStorageVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.CreateOdbSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudExadataInfrastructureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteCloudVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteDbSystemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExadbVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteExascaleDbStorageVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.DeleteOdbSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.FailoverAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GenerateAutonomousDatabaseWalletSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudExadataInfrastructureSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetCloudVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetDbSystemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExadbVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetExascaleDbStorageVaultSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetOdbSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.GetPluggableDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabaseCharacterSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListAutonomousDbVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudExadataInfrastructuresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListCloudVmClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabaseCharacterSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbNodesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbServersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemInitialStorageSizesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemShapesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbSystemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListDbVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListEntitlementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExadbVmClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListExascaleDbStorageVaultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListGiVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListMinorVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbNetworksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListOdbSubnetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.ListPluggableDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RemoveVirtualMachineExadbVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestartAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.RestoreAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StartAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.StopAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.SwitchoverAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateAutonomousDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterSnippet.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.GeneratedSnippets/OracleDatabaseClient.UpdateExadbVmClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.Snippets/OracleDatabaseClientSnippets.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1.Snippets/OracleDatabaseClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDatabaseCharacterSetResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDatabaseCharacterSetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDatabaseResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDatabaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDbBackupResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDbBackupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDbVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/AutonomousDbVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DatabaseCharacterSetResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DatabaseCharacterSetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DatabaseResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DatabaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbNodeResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbNodeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbServerResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbServerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbSystemInitialStorageSizeResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbSystemInitialStorageSizeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbSystemResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbSystemResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbSystemShapeResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbSystemShapeResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/DbVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/EntitlementResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/EntitlementResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ExadataInfraResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ExadataInfraResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ExadbVmClusterResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ExadbVmClusterResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ExascaleDbStorageVaultResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ExascaleDbStorageVaultResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/GiVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/GiVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/MinorVersionResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/MinorVersionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OdbNetworkResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OdbNetworkResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OdbSubnetResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OdbSubnetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OracleDatabaseClient.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OracleDatabaseClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OracledatabaseResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/OracledatabaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/PluggableDatabaseResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/PluggableDatabaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/VmClusterResourceNames.g.cs
+++ b/apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1/VmClusterResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CheckUpgradeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CheckUpgradeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CheckUpgradeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CheckUpgradeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsConfigMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.CreateUserWorkloadsSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DatabaseFailoverRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DatabaseFailoverRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DatabaseFailoverRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DatabaseFailoverRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsConfigMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.DeleteUserWorkloadsSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ExecuteAirflowCommandRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ExecuteAirflowCommandRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ExecuteAirflowCommandRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ExecuteAirflowCommandRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.FetchDatabasePropertiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.FetchDatabasePropertiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.FetchDatabasePropertiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.FetchDatabasePropertiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsConfigMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.GetUserWorkloadsSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListEnvironmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsConfigMapsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListUserWorkloadsSecretsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.ListWorkloadsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.LoadSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.LoadSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.LoadSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.LoadSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.PollAirflowCommandRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.PollAirflowCommandRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.PollAirflowCommandRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.PollAirflowCommandRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.SaveSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.SaveSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.SaveSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.SaveSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.StopAirflowCommandRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.StopAirflowCommandRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.StopAirflowCommandRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.StopAirflowCommandRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsConfigMapSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/EnvironmentsClient.UpdateUserWorkloadsSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.GeneratedSnippets/ImageVersionsClient.ListImageVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets/EnvironmentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets/EnvironmentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets/ImageVersionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1.Snippets/ImageVersionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/EnvironmentsClient.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/EnvironmentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/EnvironmentsResourceNames.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/EnvironmentsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ImageVersionsClient.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ImageVersionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreateCustomConstraintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicyResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicySnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.CreatePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeleteCustomConstraintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicySnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.DeletePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetCustomConstraintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicySnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetEffectivePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicySnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.GetPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListConstraintsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListCustomConstraintsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.ListPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdateCustomConstraintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicySnippet.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.GeneratedSnippets/OrgPolicyClient.UpdatePolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.Snippets/OrgPolicyClientSnippets.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2.Snippets/OrgPolicyClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/ConstraintResourceNames.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/ConstraintResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/OrgPolicyClient.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/OrgPolicyClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/OrgpolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/OrgpolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CancelPatchJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CancelPatchJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CancelPatchJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CancelPatchJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.CreatePatchDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.DeletePatchDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ExecutePatchJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ExecutePatchJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ExecutePatchJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ExecutePatchJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.GetPatchJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobInstanceDetailsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ListPatchJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.PausePatchDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.ResumePatchDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigServiceClient.UpdatePatchDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventorySnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/OsConfigServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/OsConfigServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/OsConfigZonalServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1.Snippets/OsConfigZonalServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/InventoryResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/InventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigZonalServiceClient.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsConfigZonalServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsPolicyAssignmentReportsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsPolicyAssignmentReportsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsPolicyAssignmentsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsPolicyAssignmentsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsconfigServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/OsconfigServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchDeploymentsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchDeploymentsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchJobsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/PatchJobsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/VulnerabilityResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1/VulnerabilityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.CreateOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.DeleteOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInstanceOSPoliciesComplianceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventorySnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.GetVulnerabilityReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInstanceOSPoliciesCompliancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListOSPolicyAssignmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.ListVulnerabilityReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentSnippet.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.GeneratedSnippets/OsConfigZonalServiceClient.UpdateOSPolicyAssignmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.Snippets/OsConfigZonalServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha.Snippets/OsConfigZonalServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/InstanceOsPoliciesComplianceResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/InstanceOsPoliciesComplianceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/InventoryResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/InventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsConfigZonalServiceClient.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsConfigZonalServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsPolicyAssignmentReportsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsPolicyAssignmentReportsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsPolicyAssignmentsResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsPolicyAssignmentsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsconfigZonalServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/OsconfigZonalServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/VulnerabilityResourceNames.g.cs
+++ b/apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha/VulnerabilityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/OsLoginServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1.Snippets/OsLoginServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsLoginServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsloginResourceNames.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/OsloginResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.CreateSshPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeletePosixAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.DeleteSshPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetLoginProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.GetSshPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKey2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.ImportSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeySnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.SignSshPublicKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2Snippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKey2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.GeneratedSnippets/OsLoginServiceClient.UpdateSshPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/OsLoginServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta.Snippets/OsLoginServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsLoginServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsloginResourceNames.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/OsloginResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.GeneratedSnippets/ParallelstoreClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.Snippets/ParallelstoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1.Snippets/ParallelstoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/ParallelstoreClient.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/ParallelstoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/ParallelstoreResourceNames.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/ParallelstoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ExportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ImportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.GeneratedSnippets/ParallelstoreClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.Snippets/ParallelstoreClientSnippets.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta.Snippets/ParallelstoreClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ParallelstoreClient.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ParallelstoreClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ParallelstoreResourceNames.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ParallelstoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.CreateParameterVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.DeleteParameterVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.GetParameterVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParameterVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.ListParametersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.RenderParameterVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionSnippet.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.GeneratedSnippets/ParameterManagerClient.UpdateParameterVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.Snippets/ParameterManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1.Snippets/ParameterManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/ParameterManagerClient.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/ParameterManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingSnippet.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.GeneratedSnippets/PhishingProtectionServiceV1Beta1Client.ReportPhishingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.Snippets/PhishingProtectionServiceV1Beta1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1.Snippets/PhishingProtectionServiceV1Beta1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingProtectionServiceV1Beta1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingprotectionResourceNames.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/PhishingprotectionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.CreateOrgPolicyViolationsPreviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.GetOrgPolicyViolationsPreviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsPreviewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/OrgPolicyViolationsPreviewServiceClient.ListOrgPolicyViolationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplaySnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.CreateReplaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplayResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplaySnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.GetReplaySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsSnippet.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.GeneratedSnippets/SimulatorClient.ListReplayResultsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.Snippets/OrgPolicyViolationsPreviewServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.Snippets/OrgPolicyViolationsPreviewServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.Snippets/SimulatorClientSnippets.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1.Snippets/SimulatorClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/OrgPolicyViolationsPreviewServiceClient.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/OrgPolicyViolationsPreviewServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/OrgpolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/OrgpolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/SimulatorClient.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/SimulatorClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/SimulatorResourceNames.g.cs
+++ b/apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1/SimulatorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets/PolicyTroubleshooterClient.TroubleshootIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets/PolicyTroubleshooterClient.TroubleshootIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets/PolicyTroubleshooterClient.TroubleshootIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.GeneratedSnippets/PolicyTroubleshooterClient.TroubleshootIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.Snippets/PolicyTroubleshooterClientSnippets.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3.Snippets/PolicyTroubleshooterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/PolicyTroubleshooterClient.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/PolicyTroubleshooterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets/IamCheckerClient.TroubleshootIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets/IamCheckerClient.TroubleshootIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets/IamCheckerClient.TroubleshootIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.GeneratedSnippets/IamCheckerClient.TroubleshootIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.Snippets/IamCheckerClientSnippets.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1.Snippets/IamCheckerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/IamCheckerClient.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/IamCheckerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchCatalogsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchCatalogsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchCatalogsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchCatalogsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.GeneratedSnippets/PrivateCatalogClient.SearchVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.Snippets/PrivateCatalogClientSnippets.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1.Snippets/PrivateCatalogClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PrivateCatalogClient.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PrivateCatalogClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PrivateCatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/PrivateCatalogResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ApproveGrantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ApproveGrantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ApproveGrantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ApproveGrantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CheckOnboardingStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CheckOnboardingStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CheckOnboardingStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CheckOnboardingStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateEntitlementSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.CreateGrantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DeleteEntitlementSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DenyGrantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DenyGrantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DenyGrantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.DenyGrantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetEntitlementSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.GetGrantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListEntitlementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.ListGrantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.RevokeGrantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.RevokeGrantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.RevokeGrantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.RevokeGrantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchEntitlementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchEntitlementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchEntitlementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchEntitlementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchGrantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchGrantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchGrantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.SearchGrantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementSnippet.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.GeneratedSnippets/PrivilegedAccessManagerClient.UpdateEntitlementSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.Snippets/PrivilegedAccessManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1.Snippets/PrivilegedAccessManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/PrivilegedAccessManagerClient.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/PrivilegedAccessManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/PrivilegedaccessmanagerResourceNames.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/PrivilegedaccessmanagerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ExportServiceClient.ListProfilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateOfflineProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.CreateProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileSnippet.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.GeneratedSnippets/ProfilerServiceClient.UpdateProfileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.Snippets/ExportServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.Snippets/ExportServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.Snippets/ProfilerServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2.Snippets/ProfilerServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ExportServiceClient.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ExportServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ProfilerResourceNames.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ProfilerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ProfilerServiceClient.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ProfilerServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.CreateTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DeleteTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DetachSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DetachSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DetachSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.DetachSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.GetTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSnapshotsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.ListTopicsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.PublishSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/PublisherServiceApiClient.UpdateTopicSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CommitSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.CreateSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.DeleteSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.GetSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemaRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ListSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.RollbackSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateMessageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateMessageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateMessageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateMessageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SchemaServiceClient.ValidateSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.AcknowledgeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.CreateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.DeleteSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.GetSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSnapshotsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ListSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyAckDeadlineSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.ModifyPushConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1Snippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2Snippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.Pull2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.PullRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.PullRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.PullRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.PullRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.SeekRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.SeekRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.SeekRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.SeekRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.StreamingPullSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.StreamingPullSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSnapshotSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionSnippet.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.GeneratedSnippets/SubscriberServiceApiClient.UpdateSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/PublisherServiceApiClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SchemaServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SchemaServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberServiceApiClientSnippets.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1.Snippets/SubscriberServiceApiClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PublisherServiceApiClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubResourceNames.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/PubsubResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SchemaResourceNames.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SchemaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SchemaServiceClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SchemaServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
+++ b/apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1/SubscriberServiceApiClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.CreateCollectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.DeleteCollectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.GetCollectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ListCollectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.PauseCollectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.RegisterCollectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.ResumeCollectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorSnippet.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.GeneratedSnippets/RapidMigrationAssessmentClient.UpdateCollectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.Snippets/RapidMigrationAssessmentClientSnippets.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1.Snippets/RapidMigrationAssessmentClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/ApiEntitiesResourceNames.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/ApiEntitiesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/RapidMigrationAssessmentClient.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/RapidMigrationAssessmentClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/RapidmigrationassessmentResourceNames.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/RapidmigrationassessmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AddIpOverrideSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.AnnotateAssessmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateAssessmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateFirewallPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.CreateKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteFirewallPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.DeleteKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetFirewallPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.GetMetricsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListFirewallPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListIpOverridesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupMembershipsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ListRelatedAccountGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.MigrateKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.MigrateKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.MigrateKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.MigrateKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RemoveIpOverrideSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.ReorderFirewallPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.RetrieveLegacySecretKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.SearchRelatedAccountGroupMembershipsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateFirewallPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeySnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.GeneratedSnippets/RecaptchaEnterpriseServiceClient.UpdateKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.Snippets/RecaptchaEnterpriseServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1.Snippets/RecaptchaEnterpriseServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaEnterpriseServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaenterpriseResourceNames.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/RecaptchaenterpriseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.AnnotateAssessmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentSnippet.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.GeneratedSnippets/RecaptchaEnterpriseServiceV1Beta1Client.CreateAssessmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets/RecaptchaEnterpriseServiceV1Beta1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1.Snippets/RecaptchaEnterpriseServiceV1Beta1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaEnterpriseServiceV1Beta1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaenterpriseResourceNames.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/RecaptchaenterpriseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.CreateCatalogItemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.DeleteCatalogItemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.GetCatalogItemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ImportCatalogItemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.ListCatalogItemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/CatalogServiceClient.UpdateCatalogItemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.CreatePredictionApiKeyRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.DeletePredictionApiKeyRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionApiKeyRegistryClient.ListPredictionApiKeyRegistrationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/PredictionServiceClient.PredictSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.CollectUserEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ImportUserEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.ListUserEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventSnippet.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.GeneratedSnippets/UserEventServiceClient.WriteUserEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/CatalogServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/CatalogServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionApiKeyRegistryClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionApiKeyRegistryClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/PredictionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/UserEventServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1.Snippets/UserEventServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/CatalogServiceClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/CatalogServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/CatalogServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/CatalogServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/ImportResourceNames.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/ImportResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionApiKeyRegistryClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionApiKeyRegistryClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionApikeyRegistryServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionApikeyRegistryServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/PredictionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/RecommendationengineResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/RecommendationengineResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/UserEventServiceClient.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/UserEventServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/UserEventServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1/UserEventServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetInsightTypeConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommendationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.GetRecommenderConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListInsightsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1Snippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2Snippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendations2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.ListRecommendationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkInsightAcceptedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationClaimedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationDismissedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationDismissedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationDismissedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationDismissedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationFailedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.MarkRecommendationSucceededSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateInsightTypeConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.GeneratedSnippets/RecommenderClient.UpdateRecommenderConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.Snippets/RecommenderClientSnippets.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1.Snippets/RecommenderClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/InsightResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/InsightResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/InsightTypeConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/InsightTypeConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommendationResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommendationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/RecommenderServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.BackupClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ExportBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ExportBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ExportBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ExportBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupCollectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupCollectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.RescheduleClusterMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.GeneratedSnippets/CloudRedisClusterClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.Snippets/CloudRedisClusterClientSnippets.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1.Snippets/CloudRedisClusterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/CloudRedisClusterClient.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/CloudRedisClusterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/CloudRedisClusterResourceNames.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/CloudRedisClusterResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ExportInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.FailoverInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ImportInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/CloudRedisClientSnippets.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1.Snippets/CloudRedisClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisResourceNames.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/CloudRedisResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ExportInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.FailoverInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceAuthStringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ImportInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.RescheduleMaintenanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.GeneratedSnippets/CloudRedisClient.UpgradeInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/CloudRedisClientSnippets.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1.Snippets/CloudRedisClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisResourceNames.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/CloudRedisResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.CreateFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.DeleteFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.ListFoldersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.MoveFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SearchFoldersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UndeleteFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/FoldersClient.UpdateFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.GetOrganizationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SearchOrganizationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/OrganizationsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.CreateProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.DeleteProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.GetProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.ListProjectsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.MoveProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SearchProjectsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UndeleteProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/ProjectsClient.UpdateProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.CreateTagBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.DeleteTagBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListEffectiveTagsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagBindingsClient.ListTagBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.CreateTagHoldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.DeleteTagHoldSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagHoldsClient.ListTagHoldsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.CreateTagKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.DeleteTagKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetNamespacedTagKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.GetTagKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.ListTagKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagKeysClient.UpdateTagKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.CreateTagValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.DeleteTagValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetNamespacedTagValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.GetTagValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.ListTagValuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueSnippet.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.GeneratedSnippets/TagValuesClient.UpdateTagValueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/FoldersClientSnippets.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/FoldersClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/OrganizationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/OrganizationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/ProjectsClientSnippets.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/ProjectsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagBindingsClientSnippets.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagBindingsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagHoldsClientSnippets.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagHoldsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagKeysClientSnippets.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagKeysClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagValuesClientSnippets.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3.Snippets/TagValuesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/FoldersClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/FoldersClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/FoldersResourceNames.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/FoldersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/OrganizationsClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/OrganizationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/OrganizationsResourceNames.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/OrganizationsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ProjectsClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ProjectsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ProjectsResourceNames.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ProjectsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagBindingsClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagBindingsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagBindingsResourceNames.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagBindingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagHoldsClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagHoldsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagHoldsResourceNames.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagHoldsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagKeysClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagKeysClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagKeysResourceNames.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagKeysResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagValuesClient.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagValuesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagValuesResourceNames.g.cs
+++ b/apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3/TagValuesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/AnalyticsServiceClient.ExportAnalyticsMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/AnalyticsServiceClient.ExportAnalyticsMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/AnalyticsServiceClient.ExportAnalyticsMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/AnalyticsServiceClient.ExportAnalyticsMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.AddCatalogAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.AddCatalogAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.AddCatalogAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.AddCatalogAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetAttributesConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetCompletionConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.GetDefaultBranchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ListCatalogsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.RemoveCatalogAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.RemoveCatalogAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.RemoveCatalogAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.RemoveCatalogAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ReplaceCatalogAttributeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ReplaceCatalogAttributeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ReplaceCatalogAttributeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.ReplaceCatalogAttributeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.SetDefaultBranchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateAttributesConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCatalogSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CatalogServiceClient.UpdateCompletionConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.CompleteQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.ImportCompletionDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.ImportCompletionDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.ImportCompletionDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/CompletionServiceClient.ImportCompletionDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.CreateControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.DeleteControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.GetControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.ListControlsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ControlServiceClient.UpdateControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ConversationalSearchServiceClient.ConversationalSearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ConversationalSearchServiceClient.ConversationalSearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.BatchUpdateGenerativeQuestionConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.GetGenerativeQuestionsFeatureConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.ListGenerativeQuestionConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/GenerativeQuestionServiceClient.UpdateGenerativeQuestionsFeatureConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.CreateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.DeleteModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.GetModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ListModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.PauseModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.ResumeModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.TuneModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ModelServiceClient.UpdateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/PredictionServiceClient.PredictRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddFulfillmentPlacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.AddLocalInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.CreateProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.DeleteProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.GetProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ImportProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ImportProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ImportProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ImportProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.ListProductsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.PurgeProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.PurgeProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.PurgeProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.PurgeProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveFulfillmentPlacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.RemoveLocalInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventorySnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.SetInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ProductServiceClient.UpdateProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/SearchServiceClient.SearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/SearchServiceClient.SearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/SearchServiceClient.SearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/SearchServiceClient.SearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.AddControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.CreateServingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.DeleteServingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.GetServingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.ListServingConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.RemoveControlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/ServingConfigServiceClient.UpdateServingConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.CollectUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.ImportUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.PurgeUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.RejoinUserEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.RejoinUserEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.RejoinUserEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.RejoinUserEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.GeneratedSnippets/UserEventServiceClient.WriteUserEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/AnalyticsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/AnalyticsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/CatalogServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/CatalogServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/CompletionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/CompletionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ControlServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ControlServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ConversationalSearchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ConversationalSearchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/GenerativeQuestionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/GenerativeQuestionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ModelServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ModelServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/PredictionServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/PredictionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ProductServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ProductServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/SearchServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/SearchServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ServingConfigServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/ServingConfigServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/UserEventServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2.Snippets/UserEventServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/AnalyticsServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/AnalyticsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CatalogServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CompletionServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CompletionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CompletionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/CompletionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ControlResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ControlResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ControlServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ControlServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ControlServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ControlServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ConversationalSearchServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ConversationalSearchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ConversationalSearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ConversationalSearchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/GenerativeQuestionServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/GenerativeQuestionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/GenerativeQuestionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/GenerativeQuestionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ImportConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ImportConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ModelResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ModelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ModelServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ModelServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ModelServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ModelServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PredictionServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PredictionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ProductServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PurgeConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/PurgeConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/SearchServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/SearchServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/SearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/SearchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServingConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServingConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServingConfigServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServingConfigServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServingConfigServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/ServingConfigServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/UserEventServiceClient.g.cs
+++ b/apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2/UserEventServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/BuildsClient.SubmitBuildRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/BuildsClient.SubmitBuildRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/BuildsClient.SubmitBuildRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/BuildsClient.SubmitBuildRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.CancelExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.DeleteExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.GetExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ExecutionsClient.ListExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.RunJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/JobsClient.UpdateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.DeleteRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.GetRevisionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/RevisionsClient.ListRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService1Snippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService2Snippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateService2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/ServicesClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.GetTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/TasksClient.ListTasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.CreateWorkerPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.DeleteWorkerPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.GetWorkerPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.ListWorkerPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool1Snippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool2Snippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPool2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.GeneratedSnippets/WorkerPoolsClient.UpdateWorkerPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/BuildsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/BuildsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/ExecutionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/ExecutionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/JobsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/JobsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/RevisionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/RevisionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/ServicesClientSnippets.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/ServicesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/TasksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/TasksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/WorkerPoolsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2.Snippets/WorkerPoolsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/BuildResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/BuildResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/BuildsClient.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/BuildsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ExecutionResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ExecutionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ExecutionsClient.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ExecutionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/InstanceSplitResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/InstanceSplitResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/JobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/JobsClient.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/JobsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/K8SMinResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/K8SMinResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/RevisionResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/RevisionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/RevisionTemplateResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/RevisionTemplateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/RevisionsClient.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/RevisionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServicesClient.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/ServicesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TaskResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TaskTemplateResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TaskTemplateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TasksClient.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TasksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TrafficTargetResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/TrafficTargetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/VendorSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/VendorSettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/WorkerPoolResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/WorkerPoolResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/WorkerPoolRevisionTemplateResourceNames.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/WorkerPoolRevisionTemplateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/WorkerPoolsClient.g.cs
+++ b/apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2/WorkerPoolsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateSaasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.CreateUnitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteSaasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.DeleteUnitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetSaasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.GetUnitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListReleasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListSaasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListTenantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitKindsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.ListUnitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateReleaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateSaasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasDeploymentsClient.UpdateUnitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.CreateRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.DeleteRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.GetRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutKindsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.ListRolloutsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutKindSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.GeneratedSnippets/SaasRolloutsClient.UpdateRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.Snippets/SaasDeploymentsClientSnippets.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.Snippets/SaasDeploymentsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.Snippets/SaasRolloutsClientSnippets.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1.Snippets/SaasRolloutsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/DeploymentsResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/DeploymentsResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/DeploymentsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/DeploymentsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/RolloutsResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/RolloutsResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/RolloutsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/RolloutsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/SaasDeploymentsClient.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/SaasDeploymentsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/SaasRolloutsClient.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/SaasRolloutsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/Google.Cloud.SaasPlatform.SaasServiceMgmt.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.PauseJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.ResumeJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.RunJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.GeneratedSnippets/CloudSchedulerClient.UpdateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.Snippets/CloudSchedulerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1.Snippets/CloudSchedulerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudSchedulerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudschedulerResourceNames.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/CloudschedulerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/JobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/TargetResourceNames.g.cs
+++ b/apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1/TargetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.Snippets/SecretManagerServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1.Snippets/SecretManagerServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/SecretManagerServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.CreateSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.ListSecretsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.Snippets/SecretManagerServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1.Snippets/SecretManagerServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/SecretManagerServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AccessSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.AddSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.CreateSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DeleteSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DestroySecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.DisableSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.EnableSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.GetSecretVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.ListSecretsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretSnippet.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.GeneratedSnippets/SecretManagerServiceClient.UpdateSecretSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.Snippets/SecretManagerServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2.Snippets/SecretManagerServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/SecretManagerServiceClient.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/SecretManagerServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ActivateCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCaPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.CreateCertificateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCaPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DeleteCertificateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.DisableCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.EnableCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCaCertsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.FetchCertificateAuthorityCsrSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCaPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateRevocationListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.GetCertificateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCaPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateAuthoritiesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateRevocationListsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificateTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.ListCertificatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.RevokeCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthorityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UndeleteCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCaPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthorityAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthorityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthorityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthorityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthorityRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthorityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthoritySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateAuthoritySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateRevocationListSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.GeneratedSnippets/CertificateAuthorityServiceClient.UpdateCertificateTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.Snippets/CertificateAuthorityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1.Snippets/CertificateAuthorityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/CertificateAuthorityServiceClient.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/CertificateAuthorityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.Snippets/PublicCertificateAuthorityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1.Snippets/PublicCertificateAuthorityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/PublicCertificateAuthorityServiceClient.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/PublicCertificateAuthorityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeySnippet.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.GeneratedSnippets/PublicCertificateAuthorityServiceClient.CreateExternalAccountKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.Snippets/PublicCertificateAuthorityServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1.Snippets/PublicCertificateAuthorityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/PublicCertificateAuthorityServiceClient.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/PublicCertificateAuthorityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchCalculateEffectiveSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchCalculateEffectiveSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchCalculateEffectiveSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchCalculateEffectiveSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchGetSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchGetSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchGetSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.BatchGetSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveComponentSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.CalculateEffectiveSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetComponentSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetServiceAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.GetSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListComponentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ListDetectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetComponentSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetComponentSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetComponentSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetComponentSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.ResetSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateComponentSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.GeneratedSnippets/SecurityCenterSettingsServiceClient.UpdateSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets/SecurityCenterSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1.Snippets/SecurityCenterSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ComponentSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ComponentSettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecurityCenterSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecuritycenterSettingsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SecuritycenterSettingsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1/SettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateFindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames5AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames5AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames5Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames5Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames6AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames6AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames6Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1ResourceNames6Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames5AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames5AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames5Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames5Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames6AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames6AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames6Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2ResourceNames6Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.CreateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.DeleteSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEffectiveSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetMuteConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSimulationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GetValuedResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.GroupFindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListAttackPathsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantEventThreatDetectionCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListDescendantSecurityHealthAnalyticsCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveEventThreatDetectionCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEffectiveSecurityHealthAnalyticsCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListEventThreatDetectionCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSecurityHealthAnalyticsCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoverySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoverySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetFindingStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SetMuteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.SimulateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateFindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.UpdateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ValidateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ValidateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ValidateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.GeneratedSnippets/SecurityCenterClient.ValidateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.Snippets/SecurityCenterClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1.Snippets/SecurityCenterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AssetResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AssetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AttackPathResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/AttackPathResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/BigqueryExportResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/BigqueryExportResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/CloudDlpDataProfileResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/CloudDlpDataProfileResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/CloudDlpInspectionResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/CloudDlpInspectionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/EffectiveEventThreatDetectionCustomModuleResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/EffectiveEventThreatDetectionCustomModuleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/EffectiveSecurityHealthAnalyticsCustomModuleResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/EffectiveSecurityHealthAnalyticsCustomModuleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/EventThreatDetectionCustomModuleResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/EventThreatDetectionCustomModuleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ExternalSystemResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ExternalSystemResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/FindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/MuteConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/MuteConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/NotificationConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/NotificationConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrgPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrgPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrganizationSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/OrganizationSettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ResourceValueConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ResourceValueConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityCenterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityHealthAnalyticsCustomModuleResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityHealthAnalyticsCustomModuleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityMarksResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecurityMarksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecuritycenterServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SecuritycenterServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SimulationResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SimulationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/SourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ValuedResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1/ValuedResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFinding2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.CreateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetOrganizationSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GetSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.GroupFindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListFindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.ListSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoveryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoverySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.RunAssetDiscoverySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetFindingStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFinding2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfig2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateOrganizationSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarks2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSource2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets/SecurityCenterClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1.Snippets/SecurityCenterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/AssetResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/AssetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/FindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/NotificationConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/NotificationConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/OrganizationSettingsResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/OrganizationSettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityCenterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityMarksResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecurityMarksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecuritycenterServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SecuritycenterServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1/SourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BatchCreateResourceValueConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.BulkMuteFindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateFindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames5AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames5AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames5Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames5Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames6AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames6AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames6Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigResourceNames6Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateMuteConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.CreateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteMuteConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.DeleteResourceValueConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetMuteConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetResourceValueConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSimulationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GetValuedResourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.GroupFindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListAttackPathsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListBigQueryExportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListFindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames4Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames5Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsResourceNames6Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListMuteConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListNotificationConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListResourceValueConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.ListValuedResourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetFindingStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.SetMuteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateBigQueryExportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateExternalSystemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateFindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateMuteConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateNotificationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateResourceValueConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSecurityMarksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.GeneratedSnippets/SecurityCenterClient.UpdateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.Snippets/SecurityCenterClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2.Snippets/SecurityCenterClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/AttackPathResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/AttackPathResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/BigqueryExportResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/BigqueryExportResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/CloudDlpDataProfileResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/CloudDlpDataProfileResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/CloudDlpInspectionResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/CloudDlpInspectionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ExternalSystemResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ExternalSystemResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/FindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/MuteConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/MuteConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/NotificationConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/NotificationConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/OrgPolicyResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/OrgPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ResourceValueConfigResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ResourceValueConfigResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SecurityCenterClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SecurityCenterClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SecurityMarksResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SecurityMarksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SecuritycenterServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SecuritycenterServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SimulationResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SimulationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/SourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ValuedResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2/ValuedResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.CreateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.DeleteSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEffectiveSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityCenterServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.GetSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantEventThreatDetectionCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListDescendantSecurityHealthAnalyticsCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveEventThreatDetectionCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEffectiveSecurityHealthAnalyticsCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListEventThreatDetectionCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityCenterServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames3AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames3AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames3Snippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesResourceNames3Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ListSecurityHealthAnalyticsCustomModulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.SimulateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateEventThreatDetectionCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityCenterServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.UpdateSecurityHealthAnalyticsCustomModuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ValidateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ValidateEventThreatDetectionCustomModuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ValidateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.GeneratedSnippets/SecurityCenterManagementClient.ValidateEventThreatDetectionCustomModuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.Snippets/SecurityCenterManagementClientSnippets.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1.Snippets/SecurityCenterManagementClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/SecurityCenterManagementClient.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/SecurityCenterManagementClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/SecurityCenterManagementResourceNames.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/SecurityCenterManagementResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/QuotaControllerClient.AllocateQuotaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/QuotaControllerClient.AllocateQuotaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/QuotaControllerClient.AllocateQuotaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/QuotaControllerClient.AllocateQuotaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.CheckRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.CheckRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.CheckRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.CheckRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.ReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.ReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.ReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.GeneratedSnippets/ServiceControllerClient.ReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.Snippets/QuotaControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.Snippets/QuotaControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.Snippets/ServiceControllerClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1.Snippets/ServiceControllerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/QuotaControllerClient.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/QuotaControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceControllerClient.g.cs
+++ b/apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1/ServiceControllerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/LookupServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/LookupServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/RegistrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1.Snippets/RegistrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/EndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/EndpointResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/LookupServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/LookupServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/LookupServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/LookupServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/NamespaceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/NamespaceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/RegistrationServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/RegistrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/RegistrationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/RegistrationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/LookupServiceClient.ResolveServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListNamespacesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateNamespaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.GeneratedSnippets/RegistrationServiceClient.UpdateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/LookupServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/LookupServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/RegistrationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1.Snippets/RegistrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/EndpointResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/EndpointResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/LookupServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/NamespaceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/NamespaceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/RegistrationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.GetOrganizationImpactSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.GeneratedSnippets/ServiceHealthClient.ListOrganizationImpactsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.Snippets/ServiceHealthClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1.Snippets/ServiceHealthClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/EventResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/EventResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/ServiceHealthClient.g.cs
+++ b/apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1/ServiceHealthClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.CreateServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.DeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GenerateConfigReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceRolloutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.GetServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServiceRolloutsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.ListServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.SubmitConfigSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.GeneratedSnippets/ServiceManagerClient.UndeleteServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.Snippets/ServiceManagerClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1.Snippets/ServiceManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceManagerClient.g.cs
+++ b/apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1/ServiceManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchEnableServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchEnableServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchEnableServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchEnableServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchGetServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchGetServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchGetServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.BatchGetServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.DisableServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.DisableServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.DisableServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.DisableServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.EnableServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.EnableServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.EnableServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.EnableServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.GetServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.GetServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.GetServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.GetServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.ListServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.ListServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.ListServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.GeneratedSnippets/ServiceUsageClient.ListServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.Snippets/ServiceUsageClientSnippets.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1.Snippets/ServiceUsageClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceUsageClient.g.cs
+++ b/apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1/ServiceUsageClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AddPublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AddPublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AddPublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AddPublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AuthorizeEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AuthorizeEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AuthorizeEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.AuthorizeEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.GetEnvironmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.RemovePublicKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.RemovePublicKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.RemovePublicKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.RemovePublicKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.StartEnvironmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.StartEnvironmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.StartEnvironmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.GeneratedSnippets/CloudShellServiceClient.StartEnvironmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.Snippets/CloudShellServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1.Snippets/CloudShellServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudShellServiceClient.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudShellServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudshellResourceNames.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/CloudshellResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.AddSplitPointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CopyBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.CreateDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DeleteBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.DropDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseDdlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.InternalUpdateGraphOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupSchedulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListBackupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabaseRolesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.ListDatabasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.RestoreDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupScheduleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateBackupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseDdlSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.GeneratedSnippets/DatabaseAdminClient.UpdateDatabaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/DatabaseAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1.Snippets/DatabaseAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupScheduleResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/BackupScheduleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/DatabaseAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/SpannerDatabaseAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1/SpannerDatabaseAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstancePartitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.CreateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstancePartitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.DeleteInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstancePartitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstanceConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancePartitionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.MoveInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.MoveInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.MoveInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.MoveInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstancePartitionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.GeneratedSnippets/InstanceAdminClient.UpdateInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/InstanceAdminClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1.Snippets/InstanceAdminClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/InstanceAdminClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1/SpannerInstanceAdminResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchCreateSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchWriteRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchWriteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchWriteResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchWriteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchWriteSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BatchWriteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.BeginTransactionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1Snippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2Snippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.Commit2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CommitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CommitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CommitRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CommitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.CreateSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.DeleteSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteBatchDmlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteBatchDmlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteBatchDmlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteBatchDmlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteSqlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteSqlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteSqlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteStreamingSqlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ExecuteStreamingSqlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.GetSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ListSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionReadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionReadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionReadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.PartitionReadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ReadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ReadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ReadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.ReadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.RollbackSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.StreamingReadRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.GeneratedSnippets/SpannerClient.StreamingReadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1.Snippets/SpannerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerResourceNames.g.cs
+++ b/apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1/SpannerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreateCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.CreatePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeleteCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.DeletePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.GetPhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListCustomClassesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.ListPhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdateCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.LongRunningRecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.RecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.StreamingRecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.GeneratedSnippets/SpeechClient.StreamingRecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/AdaptationClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/AdaptationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/SpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1.Snippets/SpeechClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/AdaptationClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/AdaptationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/CloudSpeechAdaptationResourceNames.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/CloudSpeechAdaptationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1/SpeechClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreateCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.CreatePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeleteCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.DeletePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.GetPhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListCustomClassesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.ListPhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdateCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/AdaptationClient.UpdatePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.LongRunningRecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.RecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.StreamingRecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.GeneratedSnippets/SpeechClient.StreamingRecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/AdaptationClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/AdaptationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/SpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1.Snippets/SpeechClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/AdaptationClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/AdaptationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/CloudSpeechAdaptationResourceNames.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/CloudSpeechAdaptationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ResourceResourceNames.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ResourceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1/SpeechClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.BatchRecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreatePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.CreateRecognizerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeletePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.DeleteRecognizerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetPhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.GetRecognizerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListCustomClassesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListPhraseSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.ListRecognizersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1Snippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2Snippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.Recognize2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.RecognizeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.RecognizeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.RecognizeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.RecognizeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.StreamingRecognizeSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.StreamingRecognizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeletePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UndeleteRecognizerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateCustomClassSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdatePhraseSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerSnippet.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.GeneratedSnippets/SpeechClient.UpdateRecognizerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.Snippets/SpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2.Snippets/SpeechClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/CloudSpeechResourceNames.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/CloudSpeechResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/SpeechClient.g.cs
+++ b/apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2/SpeechClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateAnywhereCacheSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.CreateManagedFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DeleteManagedFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.DisableAnywhereCacheSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetAnywhereCacheSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderIntelligenceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetManagedFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetOrganizationIntelligenceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetProjectIntelligenceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.GetStorageLayoutSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListAnywhereCachesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListFoldersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ListManagedFoldersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.PauseAnywhereCacheSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.RenameFolderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.ResumeAnywhereCacheSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateAnywhereCacheSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateFolderIntelligenceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateOrganizationIntelligenceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.GeneratedSnippets/StorageControlClient.UpdateProjectIntelligenceConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.Snippets/StorageControlClientSnippets.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2.Snippets/StorageControlClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/StorageControlClient.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/StorageControlClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/StorageControlResourceNames.g.cs
+++ b/apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2/StorageControlResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CancelJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.GeneratedSnippets/StorageBatchOperationsClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.Snippets/StorageBatchOperationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1.Snippets/StorageBatchOperationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/StorageBatchOperationsClient.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/StorageBatchOperationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/StorageBatchOperationsResourceNames.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/StorageBatchOperationsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/StorageBatchOperationsTypesResourceNames.g.cs
+++ b/apis/Google.Cloud.StorageBatchOperations.V1/Google.Cloud.StorageBatchOperations.V1/StorageBatchOperationsTypesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateDatasetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.CreateReportConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteDatasetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.DeleteReportConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetDatasetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.GetReportDetailSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.LinkDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListDatasetConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.ListReportDetailsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UnlinkDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateDatasetConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigSnippet.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.GeneratedSnippets/StorageInsightsClient.UpdateReportConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.Snippets/StorageInsightsClientSnippets.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1.Snippets/StorageInsightsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/StorageInsightsClient.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/StorageInsightsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/StorageinsightsResourceNames.g.cs
+++ b/apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1/StorageinsightsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateAgentPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateTransferJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateTransferJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateTransferJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.CreateTransferJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteAgentPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteTransferJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteTransferJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteTransferJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.DeleteTransferJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetAgentPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetGoogleServiceAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetGoogleServiceAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetGoogleServiceAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetGoogleServiceAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetTransferJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetTransferJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetTransferJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.GetTransferJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListAgentPoolsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListTransferJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListTransferJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListTransferJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ListTransferJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.PauseTransferOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.PauseTransferOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.PauseTransferOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.PauseTransferOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ResumeTransferOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ResumeTransferOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ResumeTransferOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.ResumeTransferOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.RunTransferJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.RunTransferJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.RunTransferJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.RunTransferJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateAgentPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateTransferJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateTransferJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateTransferJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.GeneratedSnippets/StorageTransferServiceClient.UpdateTransferJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.Snippets/StorageTransferServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1.Snippets/StorageTransferServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/StorageTransferServiceClient.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/StorageTransferServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/TransferTypesResourceNames.g.cs
+++ b/apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1/TransferTypesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.CreateCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.GetCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.ListCasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CaseServiceClient.UpdateCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.CreateCommentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.GeneratedSnippets/CommentServiceClient.ListCommentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/CaseAttachmentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/CaseAttachmentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/CaseServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/CaseServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/CommentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2.Snippets/CommentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/AttachmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/AttachmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/AttachmentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/AttachmentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseAttachmentServiceClient.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseAttachmentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseServiceClient.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CaseServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CommentResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CommentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CommentServiceClient.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CommentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CommentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/CommentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.GetAttachmentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseAttachmentServiceClient.ListAttachmentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CloseCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.CreateCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.EscalateCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.GetCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.ListCasesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCaseClassificationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.SearchCasesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CaseServiceClient.UpdateCaseSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.CreateCommentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.GetCommentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/CommentServiceClient.ListCommentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedSnippet.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.GeneratedSnippets/FeedServiceClient.ShowFeedSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/CaseAttachmentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/CaseAttachmentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/CaseServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/CaseServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/CommentServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/CommentServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/FeedServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta.Snippets/FeedServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/AttachmentResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/AttachmentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/AttachmentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/AttachmentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseAttachmentServiceClient.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseAttachmentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseServiceClient.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CaseServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CommentResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CommentResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CommentServiceClient.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CommentServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CommentServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/CommentServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/EmailMessageResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/EmailMessageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/FeedServiceClient.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/FeedServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/FeedServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/FeedServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Support.V2Beta/Google.Cloud.Support.V2Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.CreateCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.DeleteCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.GetCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.ListCompaniesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompanyServiceClient.UpdateCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/EventServiceClient.CreateClientEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchCreateJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchDeleteJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.BatchUpdateJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/JobServiceClient.UpdateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.CreateTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.DeleteTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.GetTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.ListTenantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.GeneratedSnippets/TenantServiceClient.UpdateTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/CompanyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/CompanyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/CompletionClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/CompletionClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/EventServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/EventServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/JobServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/JobServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/TenantServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4.Snippets/TenantServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompanyServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompletionClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompletionClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompletionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/CompletionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/EventServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/EventServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/EventServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/EventServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/JobServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4/TenantServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanyResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.CreateCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.DeleteCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.GetCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.ListCompaniesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanySnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompanyServiceClient.UpdateCompanySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/CompletionClient.CompleteQueryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/EventServiceClient.CreateClientEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchCreateJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchDeleteJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.BatchUpdateJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames1Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames2Snippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsResourceNames2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsForAlertRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.SearchJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/JobServiceClient.UpdateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.CreateTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.DeleteTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.GetTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.ListTenantsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantSnippet.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.GeneratedSnippets/TenantServiceClient.UpdateTenantSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/CompanyServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/CompanyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/CompletionClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/CompletionClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/EventServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/EventServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/JobServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/JobServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/TenantServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1.Snippets/TenantServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompanyServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/CompletionServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/EventServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/JobServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1/TenantServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.CreateTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.DeleteTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.GetTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListQueuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ListTasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PauseQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.PurgeQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.ResumeQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.RunTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.GeneratedSnippets/CloudTasksClient.UpdateQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/CloudTasksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2.Snippets/CloudTasksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudTasksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudtasksResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/CloudtasksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/QueueResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/QueueResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2/TaskResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.CreateTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.DeleteTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.GetTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListQueuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ListTasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PauseQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.PurgeQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.ResumeQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.RunTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicySnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.SetIamPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.TestIamPermissionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueSnippet.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.GeneratedSnippets/CloudTasksClient.UpdateQueueSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/CloudTasksClientSnippets.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3.Snippets/CloudTasksClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudTasksClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudtasksResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/CloudtasksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/QueueResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/QueueResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/TaskResourceNames.g.cs
+++ b/apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3/TaskResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApplyHydratedDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ApproveBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ComputeDeploymentStatusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateEdgeSlmSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.CreateOrchestrationClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteEdgeSlmSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DeleteOrchestrationClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardBlueprintChangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.DiscardDeploymentChangesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetEdgeSlmSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetHydratedDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetOrchestrationClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.GetPublicBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListBlueprintsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListEdgeSlmsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListHydratedDeploymentsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListOrchestrationClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ListPublicBlueprintsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.ProposeBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RejectBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RemoveDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.RollbackDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchBlueprintRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.SearchDeploymentRevisionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateBlueprintSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentSnippet.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.GeneratedSnippets/TelcoAutomationClient.UpdateHydratedDeploymentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.Snippets/TelcoAutomationClientSnippets.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1.Snippets/TelcoAutomationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/TelcoAutomationClient.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/TelcoAutomationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/TelcoautomationResourceNames.g.cs
+++ b/apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1/TelcoautomationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.ListVoicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.StreamingSynthesizeSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.StreamingSynthesizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/TextToSpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/TextToSpeechClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/TextToSpeechLongAudioSynthesizeClientSnippets.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1.Snippets/TextToSpeechLongAudioSynthesizeClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/CloudTtsResourceNames.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/CloudTtsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechLongAudioSynthesizeClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1/TextToSpeechLongAudioSynthesizeClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.ListVoicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.StreamingSynthesizeSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.StreamingSynthesizeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechClient.SynthesizeSpeechSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.GeneratedSnippets/TextToSpeechLongAudioSynthesizeClient.SynthesizeLongAudioRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.Snippets/TextToSpeechClientSnippets.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.Snippets/TextToSpeechClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.Snippets/TextToSpeechLongAudioSynthesizeClientSnippets.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1.Snippets/TextToSpeechLongAudioSynthesizeClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/CloudTtsResourceNames.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/CloudTtsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/TextToSpeechClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/TextToSpeechClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/TextToSpeechLongAudioSynthesizeClient.g.cs
+++ b/apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1/TextToSpeechLongAudioSynthesizeClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.CreateNodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.DeleteNodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetAcceleratorTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetNodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.GetTensorFlowVersionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListAcceleratorTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListNodesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ListTensorFlowVersionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ReimageNodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ReimageNodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ReimageNodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.ReimageNodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StartNodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StartNodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StartNodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StartNodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StopNodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StopNodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StopNodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.GeneratedSnippets/TpuClient.StopNodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.Snippets/TpuClientSnippets.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1.Snippets/TpuClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/CloudTpuResourceNames.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/CloudTpuResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/TpuClient.g.cs
+++ b/apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1/TpuClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.GetTraceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.ListTracesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.GeneratedSnippets/TraceServiceClient.PatchTracesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1.Snippets/TraceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1/TraceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.BatchWriteSpansSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.CreateSpanRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.CreateSpanRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.CreateSpanRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.GeneratedSnippets/TraceServiceClient.CreateSpanRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/TraceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2.Snippets/TraceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceResourceNames.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TraceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TracingResourceNames.g.cs
+++ b/apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2/TracingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.AdaptiveMtTranslateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateDocumentSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.BatchTranslateTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateAdaptiveMtDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.CreateModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteAdaptiveMtFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DeleteModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.DetectLanguageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ExportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetAdaptiveMtFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossaryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetModelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.GetSupportedLanguagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportAdaptiveMtFileSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ImportDataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListAdaptiveMtSentencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListExamplesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossariesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListGlossaryEntriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.ListModelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.RomanizeTextSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateDocumentRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateDocumentRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateDocumentRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateDocumentRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1Snippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2AsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2Snippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateText2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.TranslateTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntrySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryEntrySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossaryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossarySnippet.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.GeneratedSnippets/TranslationServiceClient.UpdateGlossarySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.Snippets/TranslationServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3.Snippets/TranslationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/AdaptiveMtResourceNames.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/AdaptiveMtResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/AutomlTranslationResourceNames.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/AutomlTranslationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3/TranslationServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.AddGroupMigrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCloneJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelCutoverJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelDiskMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelDiskMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelDiskMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelDiskMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CancelImageImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCloneJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateCutoverJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDatacenterConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateDiskMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateImageImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateMigratingVmSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateTargetProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.CreateUtilizationReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDatacenterConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteDiskMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteImageImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteMigratingVmSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteTargetProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.DeleteUtilizationReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ExtendMigrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ExtendMigrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ExtendMigrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ExtendMigrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventorySnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventorySnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FetchStorageInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.FinalizeMigrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCloneJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetCutoverJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDatacenterConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetDiskMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetImageImportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetMigratingVmSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetReplicationCycleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetTargetProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.GetUtilizationReportSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCloneJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListCutoverJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDatacenterConnectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListDiskMigrationJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListImageImportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListMigratingVmsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListReplicationCyclesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListTargetProjectsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ListUtilizationReportsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.PauseMigrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.PauseMigrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.PauseMigrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.PauseMigrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RemoveGroupMigrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ResumeMigrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ResumeMigrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ResumeMigrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.ResumeMigrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.RunDiskMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.StartMigrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateDiskMigrationJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateGroupSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateMigratingVmSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpdateTargetProjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpgradeApplianceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpgradeApplianceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpgradeApplianceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.GeneratedSnippets/VmMigrationClient.UpgradeApplianceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.Snippets/VmMigrationClientSnippets.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1.Snippets/VmMigrationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/VmMigrationClient.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/VmMigrationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/VmmigrationResourceNames.g.cs
+++ b/apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1/VmmigrationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateClipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateDvrSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.CreateInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteClipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteDvrSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.DeleteInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetClipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetDvrSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.GetPoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListChannelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListClipsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListDvrSessionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.ListInputsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.PreviewInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StartDistributionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.StopDistributionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateDvrSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdateInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolSnippet.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.GeneratedSnippets/LivestreamServiceClient.UpdatePoolSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.Snippets/LivestreamServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1.Snippets/LivestreamServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/LivestreamServiceClient.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/LivestreamServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/OutputsResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/OutputsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1/ServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeySnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateCdnKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateLiveSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateSlateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.CreateVodSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeySnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteCdnKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteLiveConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteSlateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.DeleteVodConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeySnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetCdnKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveAdTagDetailSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetLiveSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetSlateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodAdTagDetailSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodSessionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.GetVodStitchDetailSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListCdnKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveAdTagDetailsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListLiveConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListSlatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodAdTagDetailsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.ListVodStitchDetailsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeySnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateCdnKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateLiveConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateSlateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.GeneratedSnippets/VideoStitcherServiceClient.UpdateVodConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.Snippets/VideoStitcherServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1.Snippets/VideoStitcherServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/AdTagDetailsResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/AdTagDetailsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/CdnKeysResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/CdnKeysResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/LiveConfigsResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/LiveConfigsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/SessionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/SessionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/SlatesResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/SlatesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/StitchDetailsResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/StitchDetailsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/VideoStitcherServiceClient.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/VideoStitcherServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/VideoStitcherServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/VideoStitcherServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/VodConfigsResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1/VodConfigsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.CreateJobTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.DeleteJobTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.GetJobTemplateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobTemplatesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsSnippet.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.GeneratedSnippets/TranscoderServiceClient.ListJobsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.Snippets/TranscoderServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1.Snippets/TranscoderServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ServicesResourceNames.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/ServicesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/TranscoderServiceClient.g.cs
+++ b/apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1/TranscoderServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoSnippet.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.GeneratedSnippets/VideoIntelligenceServiceClient.AnnotateVideoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/VideoIntelligenceServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1.Snippets/VideoIntelligenceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
+++ b/apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1/VideoIntelligenceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.AsyncBatchAnnotateImagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateFilesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ImageAnnotatorClient.BatchAnnotateImagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.AddProductToProductSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.CreateReferenceImageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.DeleteReferenceImageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.GetReferenceImageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ImportProductSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductSetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsInProductSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListProductsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.ListReferenceImagesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.PurgeProductsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.RemoveProductFromProductSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSnippet.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.GeneratedSnippets/ProductSearchClient.UpdateProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ImageAnnotatorClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ProductSearchClientSnippets.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1.Snippets/ProductSearchClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ImageAnnotatorClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchResourceNames.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ProductSearchServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.AddApplicationStreamInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateDraftSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.CreateProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteDraftSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeleteProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.DeployApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetDraftSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetInstanceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.GetProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListApplicationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListDraftsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListPrebuiltProcessorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.ListProcessorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.RemoveApplicationStreamInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UndeployApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationInstancesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateApplicationStreamInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateDraftSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/AppPlatformClient.UpdateProcessorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/HealthCheckServiceClient.HealthCheckRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/HealthCheckServiceClient.HealthCheckRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/HealthCheckServiceClient.HealthCheckRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/HealthCheckServiceClient.HealthCheckRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.BatchRunProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateAnalysisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateOperatorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.CreateProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteAnalysisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteOperatorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.DeleteProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetAnalysisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetOperatorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.GetProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListAnalysesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListOperatorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListProcessesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ListPublicOperatorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.ResolveOperatorInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateAnalysisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateOperatorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/LiveVideoAnalyticsClient.UpdateProcessSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.AcquireLeaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.AcquireLeaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.AcquireLeaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.AcquireLeaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReceiveEventsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReceiveEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReceivePacketsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReceivePacketsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReleaseLeaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReleaseLeaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReleaseLeaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.ReleaseLeaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.RenewLeaseRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.RenewLeaseRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.RenewLeaseRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.RenewLeaseRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.SendPacketsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamingServiceClient.SendPacketsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.CreateStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.DeleteStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GenerateStreamHlsTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.GetStreamThumbnailSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListEventsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.ListStreamsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.MaterializeChannelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateEventSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateSeriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/StreamsServiceClient.UpdateStreamSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AddCollectionItemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.AnalyzeCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ClipAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ClipAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ClipAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ClipAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCollectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateDataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.CreateSearchHypernymSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCollectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteDataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeleteSearchHypernymSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeployIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeployIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeployIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.DeployIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateHlsUriRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateHlsUriRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateHlsUriRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateHlsUriRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateRetrievalUrlRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateRetrievalUrlRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateRetrievalUrlRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GenerateRetrievalUrlRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCollectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetDataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.GetSearchHypernymSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ImportAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ImportAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ImportAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ImportAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.IndexAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.IndexAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.IndexAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.IndexAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.IngestAssetSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.IngestAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAnnotationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCollectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListCorporaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListDataSchemasSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexEndpointsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListIndexesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ListSearchHypernymsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveCollectionItemSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveIndexAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveIndexAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveIndexAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.RemoveIndexAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.SearchIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UndeployIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UndeployIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UndeployIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UndeployIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAnnotationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateAssetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCollectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateCorpusSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateDataSchemaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexEndpointSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateIndexSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UpdateSearchHypernymSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UploadAssetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UploadAssetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UploadAssetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.UploadAssetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewCollectionItemsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsSnippet.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.GeneratedSnippets/WarehouseClient.ViewIndexedAssetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/AppPlatformClientSnippets.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/AppPlatformClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/HealthCheckServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/HealthCheckServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/LiveVideoAnalyticsClientSnippets.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/LiveVideoAnalyticsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/StreamingServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/StreamingServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/StreamsServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/StreamsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/WarehouseClientSnippets.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1.Snippets/WarehouseClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/AppPlatformClient.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/AppPlatformClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/CommonResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/CommonResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/HealthCheckServiceClient.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/HealthCheckServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/HealthServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/HealthServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/LiveVideoAnalyticsClient.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/LiveVideoAnalyticsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/LvaResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/LvaResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/LvaServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/LvaServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/PlatformResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/PlatformResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamingResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamingResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamingServiceClient.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamingServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamsResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamsResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamsServiceClient.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamsServiceResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/StreamsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/WarehouseClient.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/WarehouseClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/WarehouseResourceNames.g.cs
+++ b/apis/Google.Cloud.VisionAI.V1/Google.Cloud.VisionAI.V1/WarehouseResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAccessRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateExternalAddressSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeySnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateHcxActivationKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateLoggingServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateManagementDnsZoneBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicySnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateNetworkPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateCloudSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreatePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.CreateVmwareEngineNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAccessRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteExternalAddressSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteLoggingServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteManagementDnsZoneBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicySnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteNetworkPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateCloudSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeletePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.DeleteVmwareEngineNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.FetchNetworkPolicyExternalAddressesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsBindPermissionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetDnsForwardingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAccessRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetExternalAddressSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeySnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetHcxActivationKeySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetLoggingServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetManagementDnsZoneBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicySnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNetworkPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetNodeTypeSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateCloudSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetPrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GetVmwareEngineNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.GrantDnsBindPermissionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAccessRulesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListExternalAddressesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListHcxActivationKeysSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListLoggingServersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListManagementDnsZoneBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPeeringsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNetworkPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodeTypesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListNodesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPeeringRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateCloudsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionPeeringRoutesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListPrivateConnectionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListSubnetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ListVmwareEngineNetworksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RepairManagementDnsZoneBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetNsxCredentialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ResetVcenterCredentialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.RevokeDnsBindPermissionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowNsxCredentialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.ShowVcenterCredentialsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UndeletePrivateCloudSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateDnsForwardingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAccessRuleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateExternalAddressSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateLoggingServerSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateManagementDnsZoneBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPeeringSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicySnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateNetworkPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateCloudSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdatePrivateConnectionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateSubnetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkSnippet.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.GeneratedSnippets/VmwareEngineClient.UpdateVmwareEngineNetworkSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.Snippets/VmwareEngineClientSnippets.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1.Snippets/VmwareEngineClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/VmwareEngineClient.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/VmwareEngineClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/VmwareengineResourceNames.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/VmwareengineResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/VmwareengineResourcesResourceNames.g.cs
+++ b/apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1/VmwareengineResourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.CreateConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.DeleteConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.GetConnectorSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsSnippet.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.GeneratedSnippets/VpcAccessServiceClient.ListConnectorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.Snippets/VpcAccessServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1.Snippets/VpcAccessServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/VpcAccessResourceNames.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/VpcAccessResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/VpcAccessServiceClient.g.cs
+++ b/apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1/VpcAccessServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.ComputeThreatListDiffSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.CreateSubmissionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchHashesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SearchUrisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.GeneratedSnippets/WebRiskServiceClient.SubmitUriSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.Snippets/WebRiskServiceClientSnippets.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1.Snippets/WebRiskServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebRiskServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebriskResourceNames.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1/WebriskResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.ComputeThreatListDiffSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchHashesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisSnippet.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.GeneratedSnippets/WebRiskServiceV1Beta1Client.SearchUrisSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.Snippets/WebRiskServiceV1Beta1ClientSnippets.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1.Snippets/WebRiskServiceV1Beta1ClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
+++ b/apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1/WebRiskServiceV1Beta1Client.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.CreateScanConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.CreateScanConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.CreateScanConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.CreateScanConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.DeleteScanConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.DeleteScanConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.DeleteScanConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.DeleteScanConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetFindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetFindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetFindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetFindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.GetScanRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListCrawledUrlsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListCrawledUrlsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListCrawledUrlsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListCrawledUrlsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingTypeStatsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingTypeStatsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingTypeStatsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingTypeStatsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListFindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanRunsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanRunsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanRunsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.ListScanRunsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StartScanRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StartScanRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StartScanRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StartScanRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StopScanRunRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StopScanRunRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StopScanRunRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.StopScanRunRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.UpdateScanConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.UpdateScanConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.UpdateScanConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.GeneratedSnippets/WebSecurityScannerClient.UpdateScanConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.Snippets/WebSecurityScannerClientSnippets.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1.Snippets/WebSecurityScannerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/FindingResourceNames.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/FindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/WebSecurityScannerClient.g.cs
+++ b/apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1/WebSecurityScannerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CancelExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.CreateExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.GetExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.GeneratedSnippets/ExecutionsClient.ListExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.Snippets/ExecutionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1.Snippets/ExecutionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ExecutionsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ExecutionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ExecutionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ExecutionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CancelExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.CreateExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.GetExecutionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.GeneratedSnippets/ExecutionsClient.ListExecutionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.Snippets/ExecutionsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta.Snippets/ExecutionsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ExecutionsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ExecutionsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ExecutionsResourceNames.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ExecutionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.CreateWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.DeleteWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.GetWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowRevisionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowRevisionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowRevisionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowRevisionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.ListWorkflowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.GeneratedSnippets/WorkflowsClient.UpdateWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.Snippets/WorkflowsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.Snippets/WorkflowsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/WorkflowsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/WorkflowsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/WorkflowsResourceNames.g.cs
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/WorkflowsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.CreateWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.DeleteWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.GetWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.ListWorkflowsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowSnippet.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.GeneratedSnippets/WorkflowsClient.UpdateWorkflowSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.Snippets/WorkflowsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta.Snippets/WorkflowsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/WorkflowsClient.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/WorkflowsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/WorkflowsResourceNames.g.cs
+++ b/apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta/WorkflowsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.CreateWorkstationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.DeleteWorkstationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GenerateAccessTokenSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.GetWorkstationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListUsableWorkstationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationClustersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationConfigsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.ListWorkstationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StartWorkstationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationResourceNamesSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.StopWorkstationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationClusterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationConfigSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationRequestObjectSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationSnippet.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.GeneratedSnippets/WorkstationsClient.UpdateWorkstationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.Snippets/WorkstationsClientSnippets.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1.Snippets/WorkstationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/WorkstationsClient.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/WorkstationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/WorkstationsResourceNames.g.cs
+++ b/apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1/WorkstationsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CommitServicePerimetersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CommitServicePerimetersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CommitServicePerimetersRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CommitServicePerimetersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessLevelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateAccessPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateGcpUserAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.CreateServicePerimeterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessLevelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicySnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteAccessPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteGcpUserAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.DeleteServicePerimeterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessLevelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicySnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetAccessPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetGcpUserAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.GetServicePerimeterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessLevelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListAccessPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListGcpUserAccessBindingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersResourceNamesSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ListServicePerimetersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceAccessLevelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceAccessLevelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceAccessLevelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceAccessLevelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceServicePerimetersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceServicePerimetersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceServicePerimetersRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.ReplaceServicePerimetersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.SetIamPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.SetIamPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.SetIamPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.TestIamPermissionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.TestIamPermissionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.TestIamPermissionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessLevelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicySnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateAccessPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateGcpUserAccessBindingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterRequestObjectSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterSnippet.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.GeneratedSnippets/AccessContextManagerClient.UpdateServicePerimeterSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.Snippets/AccessContextManagerClientSnippets.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1.Snippets/AccessContextManagerClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessContextManagerClient.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessContextManagerClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessContextManagerResourceNames.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessContextManagerResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessLevelResourceNames.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessLevelResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessPolicyResourceNames.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/AccessPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/GcpUserAccessBindingResourceNames.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/GcpUserAccessBindingResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/ServicePerimeterResourceNames.g.cs
+++ b/apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1/ServicePerimeterResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.CancelOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.DeleteOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.GetOperationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsRequestObjectSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.ListOperationsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.WaitOperationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.WaitOperationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.WaitOperationRequestObjectSnippet.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.GeneratedSnippets/OperationsClient.WaitOperationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning.Snippets/OperationsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/OperationsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning/PackageApiMetadata.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.LongRunning/Google.LongRunning/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.LongRunning/Google.LongRunning/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ProvideValidationFeedbackRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ProvideValidationFeedbackRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ProvideValidationFeedbackRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ProvideValidationFeedbackRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ValidateAddressRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ValidateAddressRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ValidateAddressRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.GeneratedSnippets/AddressValidationClient.ValidateAddressRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.Snippets/AddressValidationClientSnippets.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1.Snippets/AddressValidationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/AddressValidationClient.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/AddressValidationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.LookupVideoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.LookupVideoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.LookupVideoRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.LookupVideoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoAsyncSnippet.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoSnippet.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.GeneratedSnippets/AerialViewClient.RenderVideoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.Snippets/AerialViewClientSnippets.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1.Snippets/AerialViewClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1/AerialViewClient.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1/AerialViewClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.AerialView.V1/Google.Maps.AerialView.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.GeneratedSnippets/AreaInsightsClient.ComputeInsightsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.GeneratedSnippets/AreaInsightsClient.ComputeInsightsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.GeneratedSnippets/AreaInsightsClient.ComputeInsightsRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.GeneratedSnippets/AreaInsightsClient.ComputeInsightsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.Snippets/AreaInsightsClientSnippets.g.cs
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1.Snippets/AreaInsightsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/AreaInsightsClient.g.cs
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/AreaInsightsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/AreaInsightsServiceResourceNames.g.cs
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/AreaInsightsServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.BatchCreateTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.BatchCreateTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.BatchCreateTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.BatchCreateTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateDeliveryVehicleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.CreateTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteDeliveryVehicleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.DeleteTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetDeliveryVehicleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.GetTaskTrackingInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListDeliveryVehiclesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.ListTasksSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateDeliveryVehicleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.GeneratedSnippets/DeliveryServiceClient.UpdateTaskSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.Snippets/DeliveryServiceClientSnippets.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1.Snippets/DeliveryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/DeliveryApiResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/DeliveryApiResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/DeliveryServiceClient.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/DeliveryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/DeliveryVehiclesResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/DeliveryVehiclesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/TaskTrackingInfoResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/TaskTrackingInfoResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/TasksResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1/TasksResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.CreateTripRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.CreateTripRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.CreateTripRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.CreateTripRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.DeleteTripSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.GetTripRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.GetTripRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.GetTripRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.GetTripRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.ReportBillableTripRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.ReportBillableTripRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.ReportBillableTripRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.ReportBillableTripRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.SearchTripsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.SearchTripsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.SearchTripsRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.SearchTripsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.UpdateTripRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.UpdateTripRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.UpdateTripRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/TripServiceClient.UpdateTripRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.CreateVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.CreateVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.CreateVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.CreateVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.DeleteVehicleSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.GetVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.GetVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.GetVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.GetVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.ListVehiclesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.ListVehiclesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.ListVehiclesRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.ListVehiclesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.SearchVehiclesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.SearchVehiclesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.SearchVehiclesRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.SearchVehiclesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleAttributesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleAttributesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleAttributesRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleAttributesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.GeneratedSnippets/VehicleServiceClient.UpdateVehicleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.Snippets/TripServiceClientSnippets.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.Snippets/TripServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.Snippets/VehicleServiceClientSnippets.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1.Snippets/VehicleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/TripApiResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/TripApiResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/TripServiceClient.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/TripServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/TripsResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/TripsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/VehicleApiResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/VehicleApiResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/VehicleServiceClient.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/VehicleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/VehiclesResourceNames.g.cs
+++ b/apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1/VehiclesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.CreateDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.DeleteDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.FetchDatasetErrorsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.GetDatasetSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.ListDatasetsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataSnippet.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.GeneratedSnippets/MapsPlatformDatasetsClient.UpdateDatasetMetadataSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.Snippets/MapsPlatformDatasetsClientSnippets.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1.Snippets/MapsPlatformDatasetsClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/DatasetResourceNames.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/DatasetResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/MapsPlatformDatasetsClient.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/MapsPlatformDatasetsClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/MapsPlatformDatasetsResourceNames.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/MapsPlatformDatasetsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.AutocompletePlacesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.AutocompletePlacesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.AutocompletePlacesRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.AutocompletePlacesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPhotoMediaSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceResourceNamesSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.GetPlaceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchNearbyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchNearbyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchNearbyRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchNearbyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchTextRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchTextRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchTextRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.GeneratedSnippets/PlacesClient.SearchTextRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.Snippets/PlacesClientSnippets.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1.Snippets/PlacesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/AddressDescriptorResourceNames.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/AddressDescriptorResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PhotoResourceNames.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PhotoResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PlaceResourceNames.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PlaceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PlacesClient.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PlacesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PlacesServiceResourceNames.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/PlacesServiceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ReferenceResourceNames.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ReferenceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ReviewResourceNames.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ReviewResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.Places.V1/Google.Maps.Places.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.BatchOptimizeToursRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.BatchOptimizeToursRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.BatchOptimizeToursRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.BatchOptimizeToursRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursLongRunningRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursLongRunningRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursLongRunningRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursLongRunningRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursUriRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursUriRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursUriRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.GeneratedSnippets/RouteOptimizationClient.OptimizeToursUriRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.Snippets/RouteOptimizationClientSnippets.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1.Snippets/RouteOptimizationClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1/RouteOptimizationClient.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1/RouteOptimizationClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/RoutesClient.ComputeRouteMatrixRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/RoutesClient.ComputeRouteMatrixRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/RoutesClient.ComputeRoutesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/RoutesClient.ComputeRoutesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/RoutesClient.ComputeRoutesRequestObjectSnippet.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.GeneratedSnippets/RoutesClient.ComputeRoutesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.Snippets/RoutesClientSnippets.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2.Snippets/RoutesClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/PackageApiMetadata.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/RoutesClient.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/RoutesClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.CreateAccountLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.DeleteAccountLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.ListAccountLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountLabelsServiceClient.UpdateAccountLabelSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.GetAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.ListChildAccountsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/AccountsServiceClient.UpdateLabelsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.DeleteCssProductInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.InsertCssProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.InsertCssProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.InsertCssProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.InsertCssProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductInputsServiceClient.UpdateCssProductInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.GetCssProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/CssProductsServiceClient.ListCssProductsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsSnippet.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/AccountLabelsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/AccountLabelsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/AccountsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/AccountsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/CssProductInputsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/CssProductInputsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/CssProductsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/CssProductsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/QuotaServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1.Snippets/QuotaServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountLabelsServiceClient.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountLabelsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountsLabelsResourceNames.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountsLabelsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountsResourceNames.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountsServiceClient.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/AccountsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductInputsResourceNames.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductInputsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductInputsServiceClient.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductInputsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductsResourceNames.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductsServiceClient.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/CssProductsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/QuotaResourceNames.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/QuotaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/QuotaServiceClient.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/QuotaServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.GetAccountRelationshipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.ListAccountRelationshipsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountRelationshipsServiceClient.UpdateAccountRelationshipSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ApproveAccountServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.GetAccountServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ListAccountServicesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.ProposeAccountServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountServicesServiceClient.RejectAccountServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.DeleteAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.GetAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.ListSubAccountsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AccountsServiceClient.UpdateAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentitySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentitySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetAccountForGcpRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetAccountForGcpRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetAccountForGcpRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetAccountForGcpRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.GetDeveloperRegistrationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.RegisterGcpRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.RegisterGcpRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.RegisterGcpRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.RegisterGcpRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.UnregisterGcpRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.UnregisterGcpRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.UnregisterGcpRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/DeveloperRegistrationServiceClient.UnregisterGcpRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.GetHomepageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/HomepageServiceClient.UpdateHomepageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.DisableProgramSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.EnableProgramSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.GetProgramSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ProgramsServiceClient.ListProgramsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchCreateRegionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchCreateRegionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchCreateRegionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchCreateRegionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchDeleteRegionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchDeleteRegionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchDeleteRegionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchDeleteRegionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchUpdateRegionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchUpdateRegionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchUpdateRegionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.BatchUpdateRegionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.CreateRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.DeleteRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.GetRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.ListRegionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/RegionsServiceClient.UpdateRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.CreateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.DeleteUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.GetUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.ListUsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.UpdateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.GeneratedSnippets/UserServiceClient.VerifySelfSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountIssueServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountIssueServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountRelationshipsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountRelationshipsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountServicesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountServicesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AccountsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AutofeedSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AutofeedSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AutomaticImprovementsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/AutomaticImprovementsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/BusinessIdentityServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/BusinessIdentityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/BusinessInfoServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/BusinessInfoServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/CheckoutSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/CheckoutSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/DeveloperRegistrationServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/DeveloperRegistrationServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/EmailPreferencesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/EmailPreferencesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/GbpAccountsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/GbpAccountsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/HomepageServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/HomepageServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/LfpProvidersServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/LfpProvidersServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/OmnichannelSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/OmnichannelSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/OnlineReturnPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/OnlineReturnPolicyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/ProgramsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/ProgramsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/RegionsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/RegionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/ShippingSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/ShippingSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/TermsOfServiceAgreementStateServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/TermsOfServiceAgreementStateServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/TermsOfServiceServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/TermsOfServiceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/UserServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1.Snippets/UserServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountIssueServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountIssueServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountRelationshipsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountRelationshipsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountServicesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountServicesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountissueResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountissueResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountrelationshipsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountrelationshipsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountservicesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AccountservicesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutofeedSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutofeedSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutofeedsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutofeedsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutomaticImprovementsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutomaticImprovementsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutomaticimprovementsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/AutomaticimprovementsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessIdentityServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessIdentityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessInfoServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessInfoServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessidentityResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessidentityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessinfoResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/BusinessinfoResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/CheckoutSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/CheckoutSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/CheckoutsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/CheckoutsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/DeveloperRegistrationServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/DeveloperRegistrationServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/DeveloperregistrationResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/DeveloperregistrationResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/EmailPreferencesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/EmailPreferencesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/EmailpreferencesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/EmailpreferencesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/GbpAccountsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/GbpAccountsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/GbpaccountsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/GbpaccountsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/HomepageResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/HomepageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/HomepageServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/HomepageServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/LfpProvidersServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/LfpProvidersServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/LfpprovidersResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/LfpprovidersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OmnichannelSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OmnichannelSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OmnichannelsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OmnichannelsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OnlineReturnPolicyResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OnlineReturnPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OnlineReturnPolicyServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/OnlineReturnPolicyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ProgramsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ProgramsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ProgramsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ProgramsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/RegionsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/RegionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/RegionsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/RegionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ShippingSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ShippingSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ShippingsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/ShippingsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsOfServiceAgreementStateServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsOfServiceAgreementStateServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsOfServiceServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsOfServiceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsofserviceResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsofserviceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsofserviceagreementstateResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/TermsofserviceagreementstateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/UserResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/UserResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/UserServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1/Google.Shopping.Merchant.Accounts.V1/UserServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountIssueServiceClient.ListAccountIssuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.GetAccountTaxSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.ListAccountTaxSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax1AsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax1Snippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax2AsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax2Snippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTax2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTaxRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTaxRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTaxRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountTaxServiceClient.UpdateAccountTaxRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.CreateAndConfigureAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.DeleteAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.GetAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.ListSubAccountsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AccountsServiceClient.UpdateAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.GetAutofeedSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutofeedSettingsServiceClient.UpdateAutofeedSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.GetAutomaticImprovementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/AutomaticImprovementsServiceClient.UpdateAutomaticImprovementsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentityResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentitySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.GetBusinessIdentitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentityRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentitySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessIdentityServiceClient.UpdateBusinessIdentitySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.GetBusinessInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/BusinessInfoServiceClient.UpdateBusinessInfoSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.CreateCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.DeleteCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.GetCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/CheckoutSettingsServiceClient.UpdateCheckoutSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.GetEmailPreferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/EmailPreferencesServiceClient.UpdateEmailPreferencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.LinkGbpAccountSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/GbpAccountsServiceClient.ListGbpAccountsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.ClaimHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.GetHomepageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UnclaimHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/HomepageServiceClient.UpdateHomepageSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.FindLfpProvidersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/LfpProvidersServiceClient.LinkLfpProviderSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.CreateOmnichannelSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.GetOmnichannelSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.ListOmnichannelSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.RequestInventoryVerificationSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OmnichannelSettingsServiceClient.UpdateOmnichannelSettingSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1AsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1ResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1Snippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy1Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2AsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2AsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2ResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2ResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2ResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2ResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2Snippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicy2Snippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.CreateOnlineReturnPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.DeleteOnlineReturnPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicyResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.GetOnlineReturnPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.ListOnlineReturnPoliciesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicyAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicyAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicyRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicyRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicyRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/OnlineReturnPolicyServiceClient.UpdateOnlineReturnPolicySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.DisableProgramSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.EnableProgramSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.GetProgramSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ProgramsServiceClient.ListProgramsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.CreateRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.DeleteRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.GetRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.ListRegionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/RegionsServiceClient.UpdateRegionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.GetShippingSettingsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/ShippingSettingsServiceClient.InsertShippingSettingsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.GetTermsOfServiceAgreementStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceAgreementStateServiceClient.RetrieveForApplicationTermsOfServiceAgreementStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.AcceptTermsOfServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.GetTermsOfServiceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/TermsOfServiceServiceClient.RetrieveLatestTermsOfServiceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.CreateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.DeleteUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.GetUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.ListUsersSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.GeneratedSnippets/UserServiceClient.UpdateUserSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AccountIssueServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AccountIssueServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AccountTaxServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AccountTaxServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AccountsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AccountsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AutofeedSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AutofeedSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AutomaticImprovementsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/AutomaticImprovementsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/BusinessIdentityServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/BusinessIdentityServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/BusinessInfoServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/BusinessInfoServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/CheckoutSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/CheckoutSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/EmailPreferencesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/EmailPreferencesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/GbpAccountsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/GbpAccountsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/HomepageServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/HomepageServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/LfpProvidersServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/LfpProvidersServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/OmnichannelSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/OmnichannelSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/OnlineReturnPolicyServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/OnlineReturnPolicyServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/ProgramsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/ProgramsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/RegionsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/RegionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/ShippingSettingsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/ShippingSettingsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/TermsOfServiceAgreementStateServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/TermsOfServiceAgreementStateServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/TermsOfServiceServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/TermsOfServiceServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/UserServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta.Snippets/UserServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountIssueServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountIssueServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountTaxResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountTaxResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountTaxServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountTaxServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountissueResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountissueResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AccountsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutofeedSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutofeedSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutofeedsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutofeedsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutomaticImprovementsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutomaticImprovementsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutomaticimprovementsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/AutomaticimprovementsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessIdentityServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessIdentityServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessInfoServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessInfoServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessidentityResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessidentityResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessinfoResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/BusinessinfoResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/CheckoutSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/CheckoutSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/CheckoutsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/CheckoutsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/EmailPreferencesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/EmailPreferencesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/EmailpreferencesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/EmailpreferencesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/GbpAccountsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/GbpAccountsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/GbpaccountsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/GbpaccountsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/HomepageResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/HomepageResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/HomepageServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/HomepageServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/LfpProvidersServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/LfpProvidersServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/LfpprovidersResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/LfpprovidersResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OmnichannelSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OmnichannelSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OmnichannelsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OmnichannelsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OnlineReturnPolicyResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OnlineReturnPolicyResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OnlineReturnPolicyServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/OnlineReturnPolicyServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ProgramsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ProgramsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ProgramsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ProgramsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/RegionsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/RegionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/RegionsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/RegionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ShippingSettingsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ShippingSettingsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ShippingsettingsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/ShippingsettingsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsOfServiceAgreementStateServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsOfServiceAgreementStateServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsOfServiceServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsOfServiceServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsofserviceResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsofserviceResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsofserviceagreementstateResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/TermsofserviceagreementstateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/UserResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/UserResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/UserServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta/UserServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.Snippets/ConversionSourcesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1.Snippets/ConversionSourcesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/ConversionSourcesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/ConversionSourcesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/ConversionsourcesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/ConversionsourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1/Google.Shopping.Merchant.Conversions.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.CreateConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.DeleteConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.GetConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.ListConversionSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UndeleteConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.GeneratedSnippets/ConversionSourcesServiceClient.UpdateConversionSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.Snippets/ConversionSourcesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta.Snippets/ConversionSourcesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ConversionSourcesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ConversionSourcesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ConversionsourcesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ConversionsourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.Snippets/DataSourcesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.Snippets/DataSourcesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.Snippets/FileUploadsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1.Snippets/FileUploadsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/DataSourcesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/DataSourcesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/DatasourcesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/DatasourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/FileUploadsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/FileUploadsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/FileuploadsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/FileuploadsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1/Google.Shopping.Merchant.DataSources.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.CreateDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.DeleteDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.FetchDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.GetDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.ListDataSourcesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/DataSourcesServiceClient.UpdateDataSourceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.GeneratedSnippets/FileUploadsServiceClient.GetFileUploadSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.Snippets/DataSourcesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.Snippets/DataSourcesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.Snippets/FileUploadsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta.Snippets/FileUploadsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/DataSourcesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/DataSourcesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/DatasourcesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/DatasourcesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/FileUploadsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/FileUploadsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/FileuploadsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/FileuploadsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventorySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventorySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.Snippets/LocalInventoryServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.Snippets/LocalInventoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.Snippets/RegionalInventoryServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1.Snippets/RegionalInventoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/LocalInventoryServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/LocalInventoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/LocalinventoryResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/LocalinventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/RegionalInventoryServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/RegionalInventoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/RegionalinventoryResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/RegionalinventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1/Google.Shopping.Merchant.Inventories.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventorySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.DeleteLocalInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.InsertLocalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/LocalInventoryServiceClient.ListLocalInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventoryResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventorySnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.DeleteRegionalInventorySnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.InsertRegionalInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.GeneratedSnippets/RegionalInventoryServiceClient.ListRegionalInventoriesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.Snippets/LocalInventoryServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.Snippets/LocalInventoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.Snippets/RegionalInventoryServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta.Snippets/RegionalInventoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/LocalInventoryServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/LocalInventoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/LocalinventoryResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/LocalinventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/RegionalInventoryServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/RegionalInventoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/RegionalinventoryResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/RegionalinventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.Snippets/AggregateProductStatusesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.Snippets/AggregateProductStatusesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.Snippets/IssueResolutionServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1.Snippets/IssueResolutionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/AggregateProductStatusesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/AggregateProductStatusesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/AggregateproductstatusesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/AggregateproductstatusesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/IssueResolutionServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/IssueResolutionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/IssueresolutionResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/IssueresolutionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1/Google.Shopping.Merchant.IssueResolution.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/AggregateProductStatusesServiceClient.ListAggregateProductStatusesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderAccountIssuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.RenderProductIssuesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.GeneratedSnippets/IssueResolutionServiceClient.TriggerActionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.Snippets/AggregateProductStatusesServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.Snippets/AggregateProductStatusesServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.Snippets/IssueResolutionServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta.Snippets/IssueResolutionServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/AggregateProductStatusesServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/AggregateProductStatusesServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/AggregateproductstatusesResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/AggregateproductstatusesResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/IssueResolutionServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/IssueResolutionServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/IssueresolutionResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/IssueresolutionResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.IssueResolution.V1Beta/Google.Shopping.Merchant.IssueResolution.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpInventoryServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpInventoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpMerchantStateServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpMerchantStateServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpSaleServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpSaleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1.Snippets/LfpStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpInventoryServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpInventoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpMerchantStateServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpMerchantStateServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpSaleServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpSaleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpStoreServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpinventoryResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpinventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpmerchantstateResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpmerchantstateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpsaleResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpsaleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpstoreResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/LfpstoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1/Google.Shopping.Merchant.Lfp.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpInventoryServiceClient.InsertLfpInventoryRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpMerchantStateServiceClient.GetLfpMerchantStateSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpSaleServiceClient.InsertLfpSaleRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.DeleteLfpStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.GetLfpStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.InsertLfpStoreSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.GeneratedSnippets/LfpStoreServiceClient.ListLfpStoresSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpInventoryServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpInventoryServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpMerchantStateServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpMerchantStateServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpSaleServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpSaleServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpStoreServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta.Snippets/LfpStoreServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpInventoryServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpInventoryServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpMerchantStateServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpMerchantStateServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpSaleServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpSaleServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpStoreServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpStoreServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpinventoryResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpinventoryResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpmerchantstateResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpmerchantstateResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpsaleResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpsaleResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpstoreResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/LfpstoreResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionHealthMetricsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.Snippets/NotificationsApiServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1.Snippets/NotificationsApiServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/NotificationsApiServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/NotificationsApiServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/NotificationsapiResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/NotificationsapiResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1/Google.Shopping.Merchant.Notifications.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.CreateNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.DeleteNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.GetNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.ListNotificationSubscriptionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.GeneratedSnippets/NotificationsApiServiceClient.UpdateNotificationSubscriptionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.Snippets/NotificationsApiServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta.Snippets/NotificationsApiServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/NotificationsApiServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/NotificationsApiServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/NotificationsapiResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/NotificationsapiResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.Snippets/OrderTrackingSignalsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1.Snippets/OrderTrackingSignalsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/OrderTrackingSignalsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/OrderTrackingSignalsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/OrderTrackingSignalsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/OrderTrackingSignalsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1/Google.Shopping.Merchant.OrderTracking.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.GeneratedSnippets/OrderTrackingSignalsServiceClient.CreateOrderTrackingSignalSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.Snippets/OrderTrackingSignalsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta.Snippets/OrderTrackingSignalsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/OrderTrackingSignalsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/OrderTrackingSignalsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/OrderTrackingSignalsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/OrderTrackingSignalsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.OrderTracking.V1Beta/Google.Shopping.Merchant.OrderTracking.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.GetProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.GeneratedSnippets/ProductsServiceClient.ListProductsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.Snippets/ProductInputsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.Snippets/ProductInputsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.Snippets/ProductsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1.Snippets/ProductsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductInputsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductInputsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductinputsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductinputsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ProductsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1/Google.Shopping.Merchant.Products.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.DeleteProductInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.InsertProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductInputsServiceClient.UpdateProductInputSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.GetProductSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.GeneratedSnippets/ProductsServiceClient.ListProductsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.Snippets/ProductInputsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.Snippets/ProductInputsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.Snippets/ProductsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.Snippets/ProductsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductInputsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductInputsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductinputsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductinputsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ProductsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.GetPromotionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.GeneratedSnippets/PromotionsServiceClient.ListPromotionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.Snippets/PromotionsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1.Snippets/PromotionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/PromotionsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/PromotionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/PromotionsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/PromotionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1/Google.Shopping.Merchant.Promotions.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.GetPromotionSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.InsertPromotionRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.GeneratedSnippets/PromotionsServiceClient.ListPromotionsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.Snippets/PromotionsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta.Snippets/PromotionsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/PromotionsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/PromotionsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/PromotionsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/PromotionsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.GetAccountLimitSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/AccountLimitsServiceClient.ListAccountLimitsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.Snippets/AccountLimitsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.Snippets/AccountLimitsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.Snippets/QuotaServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1.Snippets/QuotaServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/AccountLimitsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/AccountLimitsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/AccountlimitsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/AccountlimitsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/QuotaResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/QuotaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/QuotaServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/QuotaServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1/Google.Shopping.Merchant.Quota.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.GeneratedSnippets/QuotaServiceClient.ListQuotaGroupsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.Snippets/QuotaServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta.Snippets/QuotaServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/QuotaResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/QuotaResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/QuotaServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/QuotaServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.GeneratedSnippets/ReportServiceClient.SearchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.Snippets/ReportServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1.Snippets/ReportServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1/ReportServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1/ReportServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1/Google.Shopping.Merchant.Reports.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.GeneratedSnippets/ReportServiceClient.SearchSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.Snippets/ReportServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta.Snippets/ReportServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/ReportServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/ReportServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.DeleteMerchantReviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.GetMerchantReviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.InsertMerchantReviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.InsertMerchantReviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.InsertMerchantReviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.InsertMerchantReviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/MerchantReviewsServiceClient.ListMerchantReviewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.DeleteProductReviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.GetProductReviewSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.InsertProductReviewRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.InsertProductReviewRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.InsertProductReviewRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.InsertProductReviewRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsRequestObjectAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsRequestObjectSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsResourceNamesAsyncSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsResourceNamesSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsSnippet.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.GeneratedSnippets/ProductReviewsServiceClient.ListProductReviewsSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.Snippets/MerchantReviewsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.Snippets/MerchantReviewsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.Snippets/ProductReviewsServiceClientSnippets.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta.Snippets/ProductReviewsServiceClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/MerchantReviewsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/MerchantReviewsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/MerchantreviewsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/MerchantreviewsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/ProductReviewsServiceClient.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/ProductReviewsServiceClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/ProductreviewsResourceNames.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/ProductreviewsResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/ServiceCollectionExtensions.g.cs
+++ b/apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateNotesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.BatchCreateOccurrencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateNoteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.CreateOccurrenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteNoteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.DeleteOccurrenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetNoteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceNoteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.GetOccurrenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNoteOccurrencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListNotesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.ListOccurrencesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateNoteSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceRequestObjectAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceRequestObjectAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceRequestObjectSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceRequestObjectSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceResourceNamesAsyncSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceResourceNamesAsyncSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceResourceNamesSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceResourceNamesSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceSnippet.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.GeneratedSnippets/GrafeasClient.UpdateOccurrenceSnippet.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1.Snippets/GrafeasClientSnippets.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1.Snippets/GrafeasClientSnippets.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/GrafeasClient.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1/GrafeasResourceNames.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/GrafeasResourceNames.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1/PackageApiMetadata.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/PackageApiMetadata.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apis/Grafeas.V1/Grafeas.V1/ServiceCollectionExtensions.g.cs
+++ b/apis/Grafeas.V1/Grafeas.V1/ServiceCollectionExtensions.g.cs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Validation that this is only copyright changes:

```sh
git diff --cached --unified=0 | grep -v Copyright | grep -v '\-\-\-' | grep -v '+++' | grep -v @@ | grep -v "diff --git" | grep -v -E '^index'
```